### PR TITLE
refactor: git hub actions compila back end a partir do profile test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Compilar aplicação com Maven (sem testes)
         working-directory: ./backend/atendimento
-        run: mvn clean package -DskipTests
+        run: mvn clean package -Dspring-boot.run.profiles=test -DskipTests
 
       - name: Salvar artefato gerado
         uses: actions/upload-artifact@v4

--- a/backend/atendimento/src/main/resources/application-test.properties
+++ b/backend/atendimento/src/main/resources/application-test.properties
@@ -8,3 +8,8 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# Minio
+minio.endpoint=http://localhost:9000
+minio.root.user=minio
+minio.root.password=minio123


### PR DESCRIPTION
Atualização do profile `test` com as credenciais do **MinIO** e do workflow back-end que agora compila com a profile test.

Essa alteração serve para evitar erros de variáveis não encontrada, então o teste de integração tem por `default`  inicialização com as variáveis de ambiente de test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated backend build pipeline to enable test profile during packaging
  * Added local object storage configuration for testing environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->