### PR TITLE
Criação do banco de dados no neon e atualização no pom.xml

### DIFF
--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Nesta issue, foi criado o banco de dados postgres do produto atendimento no neon.bd.
Fazendo a criação das tabelas, atualizando o pom.xml para que o postgres funcionasse normalmente.

Tabelas criadas: 
<img width="1897" height="867" alt="image" src="https://github.com/user-attachments/assets/b7950a5e-65ed-435f-b906-c6f5cb3979a9" />
