### PR TITLE
refactor: desacoplamento do Firebase Auth e implementação de Mock para desenvolvimento local (#247)

### DIFF
--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -28,6 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -116,7 +116,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>${lombok.version}</version>
+							<version>1.18.30</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -100,8 +100,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
+			<optional>true</optional>
+		</dependency>
 
 
     </dependencies>
@@ -116,11 +116,9 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
-					<source>21</source>
-					<target>21</target>
-					<compilerArgs>--enable-preview</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/config/FirebaseConfig.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/config/FirebaseConfig.java
@@ -1,23 +1,20 @@
 package br.org.apae.atendimento.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 @Configuration
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
 public class FirebaseConfig {
     @Value("${firebase.json}")
     private String firebaseJson;

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/AuthController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/AuthController.java
@@ -1,16 +1,14 @@
 package br.org.apae.atendimento.controllers;
 
 import br.org.apae.atendimento.dtos.request.MagicLinkRequestDTO;
-import br.org.apae.atendimento.dtos.response.ProfissionalResponseDTO;
 import br.org.apae.atendimento.services.AuthService;
 import br.org.apae.atendimento.services.ProfissionalSaudeService;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -19,17 +17,18 @@ public class AuthController {
     private final AuthService authService;
     private final ProfissionalSaudeService profissionalService;
 
-    public AuthController(AuthService authService, ProfissionalSaudeService profissionalSaudeService) {
+    public AuthController(@Autowired(required = false) AuthService authService, ProfissionalSaudeService profissionalSaudeService) {
         this.authService = authService;
         this.profissionalService = profissionalSaudeService;
     }
 
     @PostMapping("/send-link")
     public ResponseEntity<?> sendMagicLink(@Valid @RequestBody MagicLinkRequestDTO body) {
-
         String email = body.email();
 
-        if (!profissionalService.existByEmail(email) ||  !authService.emailExisteNoFirebase(email)) {
+        boolean emailExisteNoFirebase = authService == null || authService.emailExisteNoFirebase(email);
+
+        if (!profissionalService.existByEmail(email) ||  !emailExisteNoFirebase) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
                     .body("Email não autorizado");

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/security/FirebaseAuthenticationFilter.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/security/FirebaseAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Component
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
 public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
 
     @Autowired

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/security/MockAuthenticationFilter.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/security/MockAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package br.org.apae.atendimento.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "firebase.enable", havingValue = "false", matchIfMissing = true)
+public class MockAuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${mock.user.id:44444444-4444-4444-4444-444444444444}")
+    private String mockUserId;
+
+    @PostConstruct
+    public void init() {
+        log.warn("AVISO: Firebase desabilitado. Autenticação Mockada em uso com ID: {}", mockUserId);
+    }
+
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            UsuarioAutenticado mockUser = new UsuarioAutenticado(
+                    UUID.fromString(mockUserId)
+            );
+
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(mockUser, null, Collections.emptyList());
+
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/security/SecurityConfig.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/security/SecurityConfig.java
@@ -1,10 +1,13 @@
 package br.org.apae.atendimento.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -14,31 +17,39 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final FirebaseAuthenticationFilter firebaseAuthFilter;
+    private final MockAuthenticationFilter mockAuthFilter;
 
-    public SecurityConfig(FirebaseAuthenticationFilter firebaseAuthFilter) {
+    public SecurityConfig(@Autowired(required = false) FirebaseAuthenticationFilter firebaseAuthFilter, @Autowired(required = false) MockAuthenticationFilter mockAuthFilter) {
         this.firebaseAuthFilter = firebaseAuthFilter;
+        this.mockAuthFilter = mockAuthFilter;
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> {})
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .cors(cors -> {
+                })
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/auth/send-link",
-                                "/h2/**",
-                                "/error",
-                                "/"
-                        ).permitAll()
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .addFilterBefore(firebaseAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .authorizeHttpRequests(auth ->
+                        auth.requestMatchers(
+                                        "/auth/send-link",
+                                        "/h2/**",
+                                        "/error",
+                                        "/"
+                                ).permitAll()
+                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                                .anyRequest().authenticated()
+                );
+
+        if (firebaseAuthFilter != null) {
+            http.addFilterBefore(firebaseAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        } else if (mockAuthFilter != null) {
+            http.addFilterBefore(mockAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        }
 
         return http.build();
     }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AuthService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AuthService.java
@@ -2,6 +2,7 @@ package br.org.apae.atendimento.services;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
 public class AuthService {
 
     public boolean emailExisteNoFirebase(String email) {

--- a/backend/atendimento/src/main/resources/application-dev.properties
+++ b/backend/atendimento/src/main/resources/application-dev.properties
@@ -1,1 +1,7 @@
 spring.config.import=optional:file:../docker/docker-compose.properties
+
+# Firebase desabilitado em dev
+firebase.enabled=false
+
+# ID do usuário injetado automaticamente quando o Firebase está desabilitado
+#mock.user.id=

--- a/backend/atendimento/src/main/resources/application-dev.properties
+++ b/backend/atendimento/src/main/resources/application-dev.properties
@@ -3,5 +3,5 @@ spring.config.import=optional:file:../docker/docker-compose.properties
 # Firebase desabilitado em dev
 firebase.enabled=false
 
-# ID do usuário injetado automaticamente quando o Firebase está desabilitado
+# ID do usuario injetado automaticamente quando o Firebase esta desabilitado
 #mock.user.id=

--- a/backend/atendimento/src/main/resources/application-prod.properties
+++ b/backend/atendimento/src/main/resources/application-prod.properties
@@ -20,3 +20,4 @@ cors.allowed-origins=${FRONT_END_URL}
 
 # FIREBASE
 firebase.json=${FIREBASE_SERVICE_ACCOUNT_JSON}
+firebase.enabled=true

--- a/backend/atendimento/src/main/resources/application-test.properties
+++ b/backend/atendimento/src/main/resources/application-test.properties
@@ -26,5 +26,5 @@ cors.allowed-origins=http://localhost:3000
 # Firebase desabilitado em test
 firebase.enabled=false
 
-# ID do usuário injetado automaticamente quando o Firebase está desabilitado
+# ID do usuario injetado automaticamente quando o Firebase esta desabilitado
 #mock.user.id=

--- a/backend/atendimento/src/main/resources/application-test.properties
+++ b/backend/atendimento/src/main/resources/application-test.properties
@@ -21,5 +21,10 @@ minio.root.password=minio123
 bucket.name=apae
 
 # Front
-
 cors.allowed-origins=http://localhost:3000
+
+# Firebase desabilitado em test
+firebase.enabled=false
+
+# ID do usuário injetado automaticamente quando o Firebase está desabilitado
+#mock.user.id=

--- a/backend/atendimento/src/main/resources/application.properties
+++ b/backend/atendimento/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=atendimento
-spring.profiles.active=prod
+spring.profiles.active=test
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB
 spring.main.web-application-type=servlet

--- a/backend/atendimento/src/main/resources/data-test.sql
+++ b/backend/atendimento/src/main/resources/data-test.sql
@@ -4,7 +4,7 @@ VALUES
 ('11111111-1111-1111-1111-111111111111', 'Ana', 'Dra. Ana Ribeiro', 'filipekevyn@gmail.com', '11999990001', null),
 ('22222222-2222-2222-2222-222222222222', 'Marcos', 'Dr. Marcos Oliveira', 'marcosoliveira@gmail.com', '11977770002', null),
 ('33333333-3333-3333-3333-333333333333', 'Luiz', 'Dr. Luiz Artur', 'luiz.artur.coder@gmail.com', '11977771114', 'Efn0oqQ68rMSjtimpAAQPO3KmjY2'),
-('44444444-4444-4444-4444-444444444444', 'Teste', 'Dr. Novo Teste', 'artur.luiz@academico.ifpb.edu.br', '11900000000', 'iA2d7BygJGR30pV3rlxramHkG1t1');
+('44444444-4444-4444-4444-444444444444', 'Teste', 'Dr. Novo Teste', 'teste@gmail.com', '11900000000', null);
 
 INSERT INTO paciente (id, nome_completo, data_de_nascimento, contato, cpf, responsaveis, cidade, rua, bairro, numero_casa, transtornos) VALUES
 ( 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'João Pedro Silva', DATE '2016-05-10',
@@ -15,6 +15,6 @@ INSERT INTO paciente (id, nome_completo, data_de_nascimento, contato, cpf, respo
 
 INSERT INTO profissional_paciente (profissional_id, paciente_id) VALUES
 ('44444444-4444-4444-4444-444444444444', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-('22222222-2222-2222-2222-222222222222', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+('44444444-4444-4444-4444-444444444444', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
 ('22222222-2222-2222-2222-222222222222', 'cccccccc-cccc-cccc-cccc-cccccccccccc'),
 ('33333333-3333-3333-3333-333333333333', 'dddddddd-dddd-dddd-dddd-dddddddddddd');

--- a/frontend/atendimento-app/src/app/(public)/login/page.tsx
+++ b/frontend/atendimento-app/src/app/(public)/login/page.tsx
@@ -38,13 +38,20 @@ export default function LoginPage() {
     setError("");
 
     try {
-      await api.post("/auth/send-link", { email });
+      await api.post("/auth/send-link", {email});
 
-      await sendMagicLink(email);
+      if (process.env.NEXT_PUBLIC_FIREBASE_ENABLED === "true") {
+        await sendMagicLink(email);
+        toast.success("Link de acesso enviado para o seu e-mail!");
+        router.push("/login/verificacao");
 
-      toast.success("Link de acesso enviado para o seu e-mail!");
-      router.push("/login/verificacao");
-    } catch(err) {
+      } else {
+        document.cookie = `token=dev-token-ignorado-pelo-backend; path=/; samesite=lax`;
+
+        toast.success("Login simulado com sucesso (Modo Dev)!");
+        router.push("/home")
+      }
+    } catch (err) {
       if (!isAxiosError(err))
         toast.error("Falha ao comunicar com o provedor de e-mail.");
     }

--- a/frontend/atendimento-app/src/proxy.ts
+++ b/frontend/atendimento-app/src/proxy.ts
@@ -2,6 +2,12 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function proxy(request: NextRequest) {
+  const firebaseEnabled = process.env.NEXT_PUBLIC_FIREBASE_ENABLED === "true";
+
+  if (!firebaseEnabled) {
+    return NextResponse.next();
+  }
+
   const token = request.cookies.get("token")?.value;
 
   const publicRoutes = ["/login"];

--- a/frontend/atendimento-app/src/services/axios.ts
+++ b/frontend/atendimento-app/src/services/axios.ts
@@ -17,16 +17,18 @@ api.interceptors.request.use(async (config) => {
     config.headers["Content-Type"] = "application/json";
   }
 
-  try {
-    const auth = getFirebaseAuth();
-    const user = auth.currentUser;
+  if (process.env.NEXT_PUBLIC_FIREBASE_ENABLED === "true") {
+    try {
+      const auth = getFirebaseAuth();
+      const user = auth.currentUser;
 
-    if (user) {
-      const token = await user.getIdToken();
-      config.headers.Authorization = `Bearer ${token}`;
+      if (user) {
+        const token = await user.getIdToken();
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+    } catch (error) {
+      console.error(error);
     }
-  } catch (error) {
-    console.error(error);
   }
 
   return config;


### PR DESCRIPTION
# **O que foi feito?**

Esta PR realiza o desacoplamento do Firebase Auth nos ambientes de desenvolvimento e teste. O objetivo é permitir que a equipe de desenvolvimento trabalhe de forma independente, sem depender de conexão externa, tokens do Google ou disparos de e-mail "mágicos" para validar o acesso ao sistema.

## **Mudanças Principais (Refactor)**

### Backend (Spring Boot)

Modularização do Firebase: Adicionada a flag firebase.enabled no application.properties. Agora, os beans do Firebase só são carregados se a flag for true (Produção).

Filtro de Autenticação Mock: Implementação do MockAuthenticationFilter. Em modo Dev/Test, este filtro injeta automaticamente um usuário autenticado no contexto de segurança do Spring, evitando erros de NullPointerException nos controllers.

Segurança Flexível: Ajuste na SecurityConfig para alternar dinamicamente entre o filtro real (Firebase) e o filtro Mock baseado no perfil ativo.

### Frontend (Next.js)

Bypass de Login: Adicionada lógica para identificar o ambiente de desenvolvimento. Se o Firebase estiver desativado, o sistema valida apenas a existência do e-mail no banco local e redireciona o usuário diretamente para a /home.

Persistência Fake: Criação de um cookie de sessão provisório para manter o estado de "logado" durante a navegação local.

### Como Testar (Passo a Passo)

1. Banco de Dados: Certifique-se de que o script de inicialização rodou o insert do usuário de teste:
   E-mail: teste@gmail.com
   ID: 44444444-4444-4444-4444-444444444444
2. Execução: Rode o backend no perfil dev ou test (verifique se firebase.enabled=false no log do console).
3. Login: No frontend, basta digitar teste@gmail.com e clicar em entrar. O redirecionamento para a Dashboard deve ser instantâneo.