### PR TITLE
Feat/254 sanitizacao relatorios

### DIFF
--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -105,6 +105,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+  			<!-- jsoup HTML parser library @ https://jsoup.org/ -->
+  			<groupId>org.jsoup</groupId>
+  			<artifactId>jsoup</artifactId>
+  			<version>1.22.1</version>
+		</dependency>
+
+
 
     </dependencies>
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
@@ -22,6 +22,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import br.org.apae.atendimento.dtos.request.ArquivoRequestDTO;
 import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
@@ -34,11 +37,16 @@ public class ArquivoController {
     private ArquivoService service;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ArquivoResponseDTO> upload(@RequestPart("file") MultipartFile file,
-                                                     @Valid @RequestPart("metadata") ArquivoRequestDTO arquivoRequest,
-                                                     @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado){
-        ArquivoResponseDTO anexoDTO = service.salvar(file, arquivoRequest, usuarioAutenticado.getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(anexoDTO);
+    public ResponseEntity<ArquivoResponseDTO> upload(
+        @RequestPart("file") MultipartFile file,
+        @RequestPart("metadata") String metadataJson,
+        @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        ArquivoRequestDTO metadata = mapper.readValue(metadataJson, ArquivoRequestDTO.class);
+
+        ArquivoResponseDTO dto = service.salvar(file, metadata, usuarioAutenticado.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
 
     @GetMapping("/{pacienteId}/{tipoId}")

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/ArquivoRequestDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/ArquivoRequestDTO.java
@@ -1,25 +1,33 @@
 package br.org.apae.atendimento.dtos.request;
-import com.fasterxml.jackson.annotation.JsonFormat;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 public record ArquivoRequestDTO(
 
-        @NotNull(message = "A data do arquivo é obrigatória")
-        LocalDate data,
+    @NotNull(message = "A data do arquivo é obrigatória")
+    LocalDate data,
 
-        @NotNull(message = "O tipo do arquivo é obrigatório")
-        Long tipoArquivo,
+    @NotNull(message = "O tipo do arquivo é obrigatório")
+    Long tipoArquivo,
 
-        @NotNull(message = "O ID do paciente é obrigatório")
-        UUID pacienteId,
+    @NotNull(message = "O ID do paciente é obrigatório")
+    UUID pacienteId,
 
-        @NotBlank(message = "O título do arquivo é obrigatório")
-        String titulo,
+    @NotBlank(message = "O título do arquivo é obrigatório")
+    @Pattern(
+        regexp = "^(?=.*[\\p{L}\\p{M}])[\\p{L}\\p{M}0-9 \\-:/()']*$",
+        message = "Título inválido"
+    )
+    String titulo,
 
-        String descricao
-        ){
-}
+    @Pattern(
+        regexp = "^(?=.*[\\p{L}\\p{M}])[\\p{L}\\p{M}0-9 \\-:/()'%&#]*$",
+        message = "Descrição inválida"
+    )
+    String descricao
+) {}

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
@@ -28,6 +28,9 @@ public class Arquivo {
     @Column(name = "descricao")
     private String descricao;
 
+    @Column(name = "titulo_canonical") 
+    private String tituloCanonical;
+
     @ManyToOne
     @JoinColumn(name = "tipo_id")
     private TipoArquivo tipo;
@@ -125,4 +128,13 @@ public class Arquivo {
     public void setDescricao(String descricao) {
         this.descricao = descricao;
     }
+
+    public String getTituloCanonical(){
+        return tituloCanonical;
+    }
+
+    public void setTituloCanonical(String tituloCanonical) {
+        this.tituloCanonical = tituloCanonical;
+    }
+
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ArquivoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ArquivoMapper.java
@@ -4,6 +4,8 @@ import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
 import br.org.apae.atendimento.entities.Arquivo;
 import br.org.apae.atendimento.entities.TipoArquivo;
 import br.org.apae.atendimento.repositories.PacienteRepository;
+import br.org.apae.atendimento.utils.StringSanitizer;
+
 import org.springframework.stereotype.Component;
 
 import br.org.apae.atendimento.entities.Paciente;
@@ -18,19 +20,25 @@ public class ArquivoMapper extends AbstractMapper<Arquivo, ArquivoRequestDTO, Ar
     }
 
     @Override
-    public Arquivo toEntityPadrao(ArquivoRequestDTO dtoPadraoArquivo) {
+    public Arquivo toEntityPadrao(ArquivoRequestDTO dto) {
         Arquivo arquivo = new Arquivo();
 
-        Paciente paciente = pacienteRepository.getReferenceById(dtoPadraoArquivo.pacienteId());
+        Paciente paciente = pacienteRepository.getReferenceById(dto.pacienteId());
         arquivo.setPaciente(paciente);
 
         TipoArquivo tipoArquivo = new TipoArquivo();
-        tipoArquivo.setId(dtoPadraoArquivo.tipoArquivo());
+        tipoArquivo.setId(dto.tipoArquivo());
         arquivo.setTipo(tipoArquivo);
 
-        arquivo.setData(dtoPadraoArquivo.data());
-        arquivo.setTitulo(dtoPadraoArquivo.titulo());
-        arquivo.setDescricao(dtoPadraoArquivo.descricao());
+        String tituloLimpo = StringSanitizer.normalizeSpaces(dto.titulo());
+        arquivo.setTitulo(StringSanitizer.stripHtml(tituloLimpo));
+        arquivo.setTituloCanonical(StringSanitizer.canonical(dto.titulo()));
+
+        String descLimpa = StringSanitizer.stripHtml(StringSanitizer.normalizeSpaces(dto.descricao()));
+        arquivo.setDescricao(descLimpa);
+
+        arquivo.setData(dto.data());
+
         return arquivo;
     }
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
@@ -5,6 +5,7 @@ import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
 import br.org.apae.atendimento.entities.Arquivo;
 import br.org.apae.atendimento.entities.ProfissionalSaude;
 import br.org.apae.atendimento.entities.TipoArquivo;
+import br.org.apae.atendimento.exceptions.invalid.AtendimentoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.ArquivoNotFoundException;
 import br.org.apae.atendimento.exceptions.notfound.TipoArquivoNotFoundException;
 import br.org.apae.atendimento.mappers.ArquivoMapper;
@@ -13,6 +14,8 @@ import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
 import br.org.apae.atendimento.repositories.TipoArquivoRepository;
 import br.org.apae.atendimento.services.storage.ObjectStorageService;
 import br.org.apae.atendimento.services.storage.PresignedUrlService;
+import br.org.apae.atendimento.utils.StringSanitizer;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,17 +53,28 @@ public class ArquivoService {
     @Transactional
     public ArquivoResponseDTO salvar(MultipartFile file, ArquivoRequestDTO arquivoRequest, UUID profissionalId) {
 
-        TipoArquivo tipoArquivo = tipoRepository.findById(arquivoRequest.tipoArquivo())
-                .orElseThrow(() -> new TipoArquivoNotFoundException("O tipo de arquivo selecionado é invalido"));
+        String contentType = file.getContentType();
+        if (contentType == null || !(contentType.equals("application/pdf") || contentType.startsWith("image/"))) {
+            throw new AtendimentoInvalidException("Tipo de arquivo não permitido. Use PDF ou imagem.");
+        }
 
-        String objectName = criarObjectName(arquivoRequest.pacienteId(), profissionalId,
-                arquivoRequest.tipoArquivo());
+        LocalDate hoje = LocalDate.now();
+        LocalDate minimo = hoje.minusYears(30);
+        if (arquivoRequest.data().isBefore(minimo) || arquivoRequest.data().isAfter(hoje)) {
+            throw new AtendimentoInvalidException("Data fora do intervalo permitido (últimos 30 anos até hoje).");
+        }
+
+        TipoArquivo tipoArquivo = tipoRepository.findById(arquivoRequest.tipoArquivo())
+            .orElseThrow(() -> new TipoArquivoNotFoundException("O tipo de arquivo selecionado é invalido"));
+
+        String objectName = criarObjectName(arquivoRequest.pacienteId(), profissionalId, arquivoRequest.tipoArquivo());
+        String nomeSanitizado = StringSanitizer.sanitizeFilename(file.getOriginalFilename());
 
         String url = storageService.uploadArquivo(objectName, file);
 
         Arquivo arquivo = anexoMapper.toEntityPadrao(arquivoRequest);
         arquivo.setObjectName(objectName);
-        arquivo.setNomeArquivo(file.getOriginalFilename());
+        arquivo.setNomeArquivo(nomeSanitizado);
         arquivo.setTipo(tipoArquivo);
 
         ProfissionalSaude profissionalSaude = profissionalRepository.getReferenceById(profissionalId);

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/utils/StringSanitizer.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/utils/StringSanitizer.java
@@ -1,0 +1,26 @@
+package br.org.apae.atendimento.utils;
+
+import java.util.Locale;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+
+public final class StringSanitizer {
+
+    private StringSanitizer() {} 
+
+    public static String normalizeSpaces(String s) {
+        return s == null ? null : s.trim().replaceAll("\\s+", " ");
+    }
+
+    public static String stripHtml(String s) {
+        return s == null ? null : Jsoup.clean(s, Safelist.none());
+    }
+
+    public static String canonical(String s) {
+        return s == null ? null : stripHtml(normalizeSpaces(s)).toLowerCase(Locale.ROOT);
+    }
+
+    public static String sanitizeFilename(String name) {
+        return name == null ? null : name.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+}

--- a/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
+++ b/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
@@ -19,6 +19,12 @@ import { TemplateRelatorio } from "../../../components/pdf/templateRelatorio";
 import { renderizarFormatoArquivo } from "@/utils/renderizarFormatoArquivo";
 import { PacientePdfDTO, ProfissionalPdfDTO } from "@/features/relatorio/types";
 import { RelatorioEnvioFormData } from "../types";
+import {
+  validarTexto,
+  validarDataISO,
+  validarArquivo,
+} from "@/features/relatorio/utils/sanitizeRelatorio";
+import { toast } from "sonner";
 
 interface RelatorioFormProps {
   onSubmit: (data: RelatorioEnvioFormData) => void;
@@ -112,9 +118,37 @@ export default function RelatorioForm({
     setValue("arquivo", fileList);
   };
 
+  const onSubmitLocal = (data: RelatorioEnvioFormData) => {
+    try {
+      const { titulo, descricao } = validarTexto(data.titulo, data.descricao);
+      const dataValida = validarDataISO(data.data);
+      const arquivo = data.arquivo?.[0]
+        ? validarArquivo(data.arquivo[0])
+        : undefined;
+
+      onSubmit({
+        ...data,
+        data: dataValida,
+        titulo,
+        descricao,
+        arquivo: arquivo
+          ? ({
+              0: arquivo,
+              length: 1,
+              item: () => arquivo,
+            } as unknown as FileList)
+          : data.arquivo,
+      });
+    } catch (error) {
+      const msg =
+        error instanceof Error ? error.message : "Erro ao validar anexo";
+      toast.error(msg);
+    }
+  };
+
   return (
     <form
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(onSubmitLocal)}
       className="grid gap-6 pt-5 text-[#344054]"
     >
       <div className="grid gap-2">

--- a/frontend/atendimento-app/src/features/relatorio/hooks/useRelatorio.ts
+++ b/frontend/atendimento-app/src/features/relatorio/hooks/useRelatorio.ts
@@ -6,7 +6,6 @@ import {
   RelatorioBase,
 } from "@/features/relatorio/types";
 
-
 import { toast } from "sonner";
 import { validarTamanhoArquivo } from "@/services/validarTamanhoArquivo";
 import { construirArquivoFormData } from "@/services/construirArquivoFormData";
@@ -21,6 +20,13 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { TipoArquivo } from "@/features/arquivo/types";
 import { filtroData } from "@/utils/filtroData";
+
+import {
+  normalizar,
+  validarTexto,
+  validarDataISO,
+  validarArquivo,
+} from "@/features/relatorio/utils/sanitizeRelatorio";
 
 export function useRelatorios(pacienteId: string) {
   const [dataSelecionada, setDataSelecionada] = useState<string>("");
@@ -67,12 +73,19 @@ export function useRelatorios(pacienteId: string) {
       });
     },
     onError: (error: unknown) => {
-      const mensagem =
-        error instanceof AxiosError
-          ? error.response?.data || error.message
-          : error instanceof Error
-            ? error.message
-            : String(error);
+      let mensagem: string;
+
+      if (error instanceof AxiosError) {
+        const payload = error.response?.data;
+        mensagem =
+          payload && typeof payload === "object"
+            ? JSON.stringify(payload)
+            : payload || error.message;
+      } else if (error instanceof Error) {
+        mensagem = error.message;
+      } else {
+        mensagem = String(error);
+      }
 
       toast.error(mensagem || "Erro ao enviar relatório");
     },
@@ -94,23 +107,49 @@ export function useRelatorios(pacienteId: string) {
     },
   });
 
-  function criarArquivoRelatorio(data: RelatorioEnvioFormData): FormData | undefined {
-    const request: RelatorioEnvioFormData = {
-      ...data,
-      pacienteId,
-      tipoArquivo: TipoArquivo.relatorio,
-    };
-
-    try{
-      validarTamanhoArquivo(request.arquivo);
-      return construirArquivoFormData(request);
-    }catch(error){
-      const mensagem = error instanceof Error
-            ? error.message
-            : String(error);
-       toast.error(mensagem || "Erro ao enviar anexo");
+  function criarArquivoRelatorio(
+    data: RelatorioEnvioFormData,
+  ): FormData | undefined {
+    if (!pacienteId) {
+      toast.error("Paciente não selecionado.");
+      return;
     }
-    
+    try {
+      const titulo = normalizar(data.titulo);
+      const descricao = normalizar(data.descricao);
+
+      validarTexto(titulo, descricao);
+      validarDataISO(data.data);
+      validarTamanhoArquivo(data.arquivo);
+
+      const arquivoValidado = data.arquivo?.[0]
+        ? validarArquivo(data.arquivo[0])
+        : undefined;
+
+      const fileList = arquivoValidado
+        ? ({
+            0: arquivoValidado,
+            length: 1,
+            item: () => arquivoValidado,
+            [Symbol.iterator]: function* () {
+              yield arquivoValidado;
+            },
+          } as unknown as FileList)
+        : data.arquivo;
+
+      return construirArquivoFormData({
+        ...data,
+        pacienteId,
+        tipoArquivo: TipoArquivo.relatorio,
+        titulo,
+        descricao,
+        arquivo: fileList,
+      });
+    } catch (error) {
+      const mensagem = error instanceof Error ? error.message : String(error);
+      toast.error(mensagem || "Erro ao enviar anexo");
+      return undefined;
+    }
   }
 
   async function construirEnviarArquivoRelatorio(data: RelatorioEnvioFormData) {

--- a/frontend/atendimento-app/src/features/relatorio/utils/sanitizeRelatorio.ts
+++ b/frontend/atendimento-app/src/features/relatorio/utils/sanitizeRelatorio.ts
@@ -1,0 +1,35 @@
+export const tituloRegex = /^(?=.*[\p{L}\p{M}])[\p{L}\p{M}0-9 \-:/()']*$/u;
+
+export const descricaoRegex =
+  /^(?=.*[\p{L}\p{M}])[\p{L}\p{M}0-9 \-:/()'%&#]*$/u;
+
+export const normalizar = (s = "") => s.trim().replace(/\s+/g, " ");
+
+export const sanitizeFilename = (n = "") => n.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+export function validarDataISO(dataISO: string) {
+  const hoje = new Date();
+  const min = new Date();
+  min.setFullYear(hoje.getFullYear() - 30);
+  const d = new Date(dataISO + "T00:00:00");
+  if (d < min || d > hoje)
+    throw new Error("Data fora do intervalo de 30 anos até hoje.");
+  return dataISO;
+}
+
+export function validarTexto(titulo: string, descricao: string) {
+  const t = normalizar(titulo);
+  const d = normalizar(descricao);
+  if (!tituloRegex.test(t)) throw new Error("Título inválido.");
+  if (!descricaoRegex.test(d)) throw new Error("Descrição inválida.");
+  return { titulo: t, descricao: d };
+}
+
+export function validarArquivo(file?: File) {
+  if (!file) throw new Error("Nenhum arquivo selecionado.");
+  if (!(file.type === "application/pdf" || file.type.startsWith("image/"))) {
+    throw new Error("Apenas PDF ou imagem são permitidos.");
+  }
+  const nomeSanitizado = sanitizeFilename(file.name);
+  return new File([file], nomeSanitizado, { type: file.type });
+}

--- a/frontend/atendimento-app/src/services/construirArquivoFormData.ts
+++ b/frontend/atendimento-app/src/services/construirArquivoFormData.ts
@@ -1,8 +1,8 @@
-import { isoParaBR } from "@/utils/formatarData";
 import {
   AnexoEnvioFormData,
   RelatorioEnvioFormData,
 } from "../features/anexo/components/anexoForm";
+import { sanitizeFilename } from "@/features/relatorio/utils/sanitizeRelatorio";
 
 export function construirArquivoFormData(
   data: AnexoEnvioFormData | RelatorioEnvioFormData,
@@ -11,15 +11,16 @@ export function construirArquivoFormData(
 
   if (data?.arquivo?.[0] && data?.arquivo?.length > 0) {
     const arquivo = data.arquivo[0];
-    formData.append("file", arquivo, arquivo.name);
+    formData.append("file", arquivo, sanitizeFilename(arquivo.name));
   }
   const metadata = {
-    data: isoParaBR(data.data),
+    data: data.data,
     tipoArquivo: data.tipoArquivo,
     pacienteId: data.pacienteId,
     titulo: data.titulo,
     descricao: data.descricao,
   };
+
   formData.append(
     "metadata",
     new Blob([JSON.stringify(metadata)], { type: "application/json" }),


### PR DESCRIPTION
### O que foi feito

- Upload multipart de relatório/anexo com `file` + `metadata` em JSON; controller parseia e repassa ao serviço.
- Sanitização com jsoup (`StringSanitizer`): remove HTML, normaliza espaços, canonicaliza título (lowercase) e sanitiza nome de arquivo.
- Validação de título/descrição via regex em front e back; normalização (trim + compressão de espaços).
- Regras de data: aceita apenas datas entre hoje e hoje − 30 anos (cálculo de calendário).
- Tratamento de arquivos: aceita apenas PDF ou imagem e sanitiza o nome.
- Feedback ao usuário: toasts e mensagens de erro para validações e envio.


https://github.com/user-attachments/assets/32bed991-276d-4bdd-930e-739dc92a594b
