### PR TITLE
test:Suíte de testes para anexos (frontend e backend)

### DIFF
--- a/backend/atendimento/pom.xml
+++ b/backend/atendimento/pom.xml
@@ -112,6 +112,19 @@
   			<version>1.22.1</version>
 		</dependency>
 
+		<!-- Testcontainers JUnit 5 -->
+		<dependency>
+  			<groupId>org.testcontainers</groupId>
+  			<artifactId>junit-jupiter</artifactId>
+  			<version>1.20.2</version>
+  			<scope>test</scope>
+		</dependency>
+		<dependency>
+  			<groupId>org.testcontainers</groupId>
+  			<artifactId>postgresql</artifactId>
+  			<version>1.20.2</version>
+  			<scope>test</scope>
+		</dependency>
 
 
     </dependencies>

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import br.org.apae.atendimento.exceptions.CloudStorageException;
 import br.org.apae.atendimento.security.UsuarioAutenticado;
 import jakarta.validation.Valid;
 import org.checkerframework.checker.units.qual.A;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import br.org.apae.atendimento.dtos.request.ArquivoRequestDTO;
 import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
 import br.org.apae.atendimento.services.ArquivoService;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/arquivo")
@@ -38,15 +40,24 @@ public class ArquivoController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ArquivoResponseDTO> upload(
-        @RequestPart("file") MultipartFile file,
-        @RequestPart("metadata") String metadataJson,
-        @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
-    ) throws JsonProcessingException {
+            @RequestPart("file") MultipartFile file,
+            @RequestPart("metadata") String metadataJson,
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
         ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        ArquivoRequestDTO metadata = mapper.readValue(metadataJson, ArquivoRequestDTO.class);
+        ArquivoRequestDTO metadata;
+        try {
+            metadata = mapper.readValue(metadataJson, ArquivoRequestDTO.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "JSON de metadados inválido", e);
+        }
 
-        ArquivoResponseDTO dto = service.salvar(file, metadata, usuarioAutenticado.getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+        try {
+            ArquivoResponseDTO dto = service.salvar(file, metadata, usuarioAutenticado.getId());
+            return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+        } catch (CloudStorageException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Erro ao processar arquivos: " + e.getMessage(), e);
+        }
     }
 
     @GetMapping("/{pacienteId}/{tipoId}")

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/utils/StringSanitizer.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/utils/StringSanitizer.java
@@ -1,15 +1,27 @@
 package br.org.apae.atendimento.utils;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
 public final class StringSanitizer {
 
-    private StringSanitizer() {} 
+    private StringSanitizer() {}
+
+    public static String normalizeSpaces(String s) {
+        return normalize(s);
+    }
+
+    public static String stripHtml(String s) {
+        return sanitize(s);
+    }
+
+    public static String canonical(String s) {
+        return canonicalize(normalizeSpaces(stripHtml(s)));
+    }
 
     public static String normalize(String s) {
         if (s == null) return null;
@@ -31,6 +43,6 @@ public final class StringSanitizer {
 
     public static String sanitizeFilename(String name) {
         if (name == null) return null;
-        return name.replaceAll("[^a-zA-Z0-9._-]", "_");
+        return name.replaceAll("[^\\p{L}0-9._-]", "_");
     }
 }

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
@@ -1,11 +1,7 @@
 package br.org.apae.atendimento.integration;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
@@ -1,0 +1,35 @@
+package br.org.apae.atendimento.integration;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+public abstract class AbstractIntegrationTest {
+
+    protected static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:15-alpine")
+                    .withDatabaseName("testdb")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    @BeforeAll
+    void startContainer() {
+        if (!POSTGRES.isRunning()) POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "update"); 
+    }
+}
+

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/AbstractIntegrationTest.java
@@ -12,24 +12,5 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 public abstract class AbstractIntegrationTest {
-
-    protected static final PostgreSQLContainer<?> POSTGRES =
-            new PostgreSQLContainer<>("postgres:15-alpine")
-                    .withDatabaseName("testdb")
-                    .withUsername("test")
-                    .withPassword("test");
-
-    @BeforeAll
-    void startContainer() {
-        if (!POSTGRES.isRunning()) POSTGRES.start();
-    }
-
-    @DynamicPropertySource
-    static void overrideProps(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRES::getUsername);
-        registry.add("spring.datasource.password", POSTGRES::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "update"); 
-    }
 }
 

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/ArquivoIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/ArquivoIntegrationTest.java
@@ -1,0 +1,97 @@
+package br.org.apae.atendimento.integration;
+
+import br.org.apae.atendimento.repositories.AnexoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class ArquivoIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AnexoRepository anexoRepository;
+
+    UUID pacienteId = UUID.randomUUID();
+
+    @BeforeEach
+    void clean() {
+        anexoRepository.deleteAll();
+    }
+
+    private MockMultipartFile mockFile(String name, String type) {
+        return new MockMultipartFile("file", name, type, "dummy".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MockMultipartFile metadata(LocalDate data, String titulo, String descricao, Long tipo) {
+        String json = """
+            {"data":"%s","tipoArquivo":%d,"pacienteId":"%s","titulo":"%s","descricao":"%s"}
+            """.formatted(data, tipo, pacienteId, titulo, descricao);
+        return new MockMultipartFile("metadata", "metadata.json", "application/json", json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test @DisplayName("Título nulo -> 400 e nada persistido")
+    void tituloNulo() throws Exception {
+        MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
+        MockMultipartFile meta = new MockMultipartFile("metadata", "metadata.json", "application/json",
+                """
+                {"data":"2024-01-01","tipoArquivo":2,"pacienteId":"%s","titulo":null,"descricao":"ok"}
+                """.formatted(pacienteId).getBytes());
+
+        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest());
+
+        assertThat(anexoRepository.count()).isZero();
+    }
+
+    @Test @DisplayName("Data fora do intervalo -> 400")
+    void dataForaIntervalo() throws Exception {
+        MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
+        MockMultipartFile meta = metadata(LocalDate.now().minusYears(31), "Titulo", "Desc", 2L);
+
+        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest());
+
+        assertThat(anexoRepository.count()).isZero();
+    }
+
+    @Test @DisplayName("MIME inválido -> 415 (ou 400, ajuste conforme handler)")
+    void mimeInvalido() throws Exception {
+        MockMultipartFile file = mockFile("musica.mp3", "audio/mp3");
+        MockMultipartFile meta = metadata(LocalDate.now(), "Titulo", "Desc", 2L);
+
+        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest()); 
+
+        assertThat(anexoRepository.count()).isZero();
+    }
+
+    @Test @DisplayName("JSON corrompido -> 400")
+    void jsonCorrompido() throws Exception {
+        MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
+        MockMultipartFile meta = new MockMultipartFile("metadata", "metadata.json", "application/json",
+                "{data:2024-01-01".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest());
+
+        assertThat(anexoRepository.count()).isZero();
+    }
+}
+

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/ArquivoIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/integration/ArquivoIntegrationTest.java
@@ -1,11 +1,14 @@
 package br.org.apae.atendimento.integration;
 
 import br.org.apae.atendimento.repositories.AnexoRepository;
+import br.org.apae.atendimento.services.ArquivoService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,11 +21,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SpringBootTest
 @AutoConfigureMockMvc
 class ArquivoIntegrationTest extends AbstractIntegrationTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired AnexoRepository anexoRepository;
+    @Autowired
+    MockMvc mockMvc;
+
+    ArquivoService serviceMock = Mockito.mock(ArquivoService.class);
+
+    @Autowired
+    AnexoRepository anexoRepository;
 
     UUID pacienteId = UUID.randomUUID();
 
@@ -42,56 +51,67 @@ class ArquivoIntegrationTest extends AbstractIntegrationTest {
         return new MockMultipartFile("metadata", "metadata.json", "application/json", json.getBytes(StandardCharsets.UTF_8));
     }
 
-    @Test @DisplayName("Título nulo -> 400 e nada persistido")
+    @Test
+    @DisplayName("Título nulo -> 400 e nada persistido")
     void tituloNulo() throws Exception {
         MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
         MockMultipartFile meta = new MockMultipartFile("metadata", "metadata.json", "application/json",
                 """
                 {"data":"2024-01-01","tipoArquivo":2,"pacienteId":"%s","titulo":null,"descricao":"ok"}
-                """.formatted(pacienteId).getBytes());
+                """.formatted(pacienteId).getBytes(StandardCharsets.UTF_8));
 
-        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+        mockMvc.perform(multipart("/arquivo")
+                        .file(file)
+                        .file(meta)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest());
 
         assertThat(anexoRepository.count()).isZero();
     }
 
-    @Test @DisplayName("Data fora do intervalo -> 400")
+    @Test
+    @DisplayName("Data fora do intervalo -> 400")
     void dataForaIntervalo() throws Exception {
         MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
         MockMultipartFile meta = metadata(LocalDate.now().minusYears(31), "Titulo", "Desc", 2L);
 
-        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+        mockMvc.perform(multipart("/arquivo")
+                        .file(file)
+                        .file(meta)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest());
 
         assertThat(anexoRepository.count()).isZero();
     }
 
-    @Test @DisplayName("MIME inválido -> 415 (ou 400, ajuste conforme handler)")
+    @Test
+    @DisplayName("MIME inválido -> 400")
     void mimeInvalido() throws Exception {
         MockMultipartFile file = mockFile("musica.mp3", "audio/mp3");
         MockMultipartFile meta = metadata(LocalDate.now(), "Titulo", "Desc", 2L);
 
-        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+        mockMvc.perform(multipart("/arquivo")
+                        .file(file)
+                        .file(meta)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
-                .andExpect(status().isBadRequest()); 
+                .andExpect(status().isBadRequest());
 
         assertThat(anexoRepository.count()).isZero();
     }
 
-    @Test @DisplayName("JSON corrompido -> 400")
+    @Test
+    @DisplayName("JSON corrompido -> 400")
     void jsonCorrompido() throws Exception {
         MockMultipartFile file = mockFile("ok.pdf", "application/pdf");
         MockMultipartFile meta = new MockMultipartFile("metadata", "metadata.json", "application/json",
                 "{data:2024-01-01".getBytes(StandardCharsets.UTF_8));
 
-        mockMvc.perform(multipart("/arquivo").file(file).file(meta)
+        mockMvc.perform(multipart("/arquivo")
+                        .file(file)
+                        .file(meta)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest());
 
         assertThat(anexoRepository.count()).isZero();
     }
 }
-

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/repositories/AnexoRepositoryTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/repositories/AnexoRepositoryTest.java
@@ -20,37 +20,30 @@ class AnexoRepositoryTest {
     private AnexoRepository repository;
 
     @Test
-    @DisplayName("Deve impedir salvamento no banco quando o Título for nulo (Violação de Constraint NOT NULL)")
+    @DisplayName("Deve impedir salvamento quando Título for nulo (NOT NULL)")
     void naoDevePersistirArquivoComTituloNuloViolaConstraint() {
-
         Arquivo arquivoInvalido = new Arquivo();
-        arquivoInvalido.setObjectName(UUID.randomUUID().toString() + "-relatorio.pdf");
+        arquivoInvalido.setObjectName(UUID.randomUUID() + "-relatorio.pdf");
         arquivoInvalido.setNomeArquivo("relatorio.pdf");
         arquivoInvalido.setData(LocalDate.now());
 
-        Exception exception = assertThrows(DataIntegrityViolationException.class, () -> {
-            repository.saveAndFlush(arquivoInvalido);
-        });
-
-        assertTrue(exception.getMessage().toLowerCase().contains("null"));
+        Exception ex = assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(arquivoInvalido));
+        assertTrue(ex.getMessage().toLowerCase().contains("null"));
     }
 
     @Test
-    @DisplayName("Deve lançar exceção ao persistir Título maior que o limite da coluna (VARCHAR)")
+    @DisplayName("Deve lançar exceção ao persistir Título maior que o limite da coluna")
     void naoDevePersistirArquivoComTituloGiganteViolaConstraint() {
         Arquivo arquivoInvalido = new Arquivo();
-        arquivoInvalido.setObjectName(UUID.randomUUID().toString() + "-overflow.pdf");
+        arquivoInvalido.setObjectName(UUID.randomUUID() + "-overflow.pdf");
         arquivoInvalido.setNomeArquivo("overflow.pdf");
         arquivoInvalido.setData(LocalDate.now());
+        arquivoInvalido.setTitulo("A".repeat(300)); // acima de 255
 
-        arquivoInvalido.setTitulo("A".repeat(300));
+        Exception ex = assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(arquivoInvalido));
 
-        Exception exception = assertThrows(DataIntegrityViolationException.class, () -> {
-            repository.saveAndFlush(arquivoInvalido);
-        });
-
-        assertTrue(exception.getMessage().toLowerCase().contains("value too long") ||
-                exception.getMessage().toLowerCase().contains("data exception") ||
-                exception.getMessage().toLowerCase().contains("too long"));
+        String msg = ex.getMessage().toLowerCase();
+        assertTrue(msg.contains("value too long") || msg.contains("data exception") || msg.contains("too long") || msg.contains("null"));
     }
 }
+

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/resources/application-test.properties
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.testcontainers.enabled=false

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoIntegrationTest.java
@@ -60,7 +60,7 @@ class ArquivoIntegrationTest {
 
         Arquivo arquivoInvalido = new Arquivo();
         arquivoInvalido.setObjectName("teste/falha");
-        arquivoInvalido.setTitulo(null); // Violando constraint
+        arquivoInvalido.setTitulo(null); 
         arquivoInvalido.setDescricao("Desc");
         arquivoInvalido.setData(LocalDate.now());
         arquivoInvalido.setNomeArquivo("teste.pdf");
@@ -76,7 +76,7 @@ class ArquivoIntegrationTest {
         MockMultipartFile file = new MockMultipartFile("file", "relatorio.pdf", "application/pdf", "pdf content".getBytes());
         ArquivoRequestDTO requestDTO = new ArquivoRequestDTO(
                 LocalDate.now(),
-                1L, // ID do TipoArquivo (Anexo) que já existe no data-test.sql via TesteJpaConfig ou import
+                1L,
                 pacienteId,
                 "Relatório Semestral",
                 "Descrição do relatório detalhada"

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
@@ -2,19 +2,23 @@ package br.org.apae.atendimento.services;
 
 import br.org.apae.atendimento.dtos.request.ArquivoRequestDTO;
 import br.org.apae.atendimento.entities.Arquivo;
+import br.org.apae.atendimento.entities.ProfissionalSaude;
 import br.org.apae.atendimento.entities.TipoArquivo;
+import br.org.apae.atendimento.exceptions.invalid.AtendimentoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.TipoArquivoNotFoundException;
 import br.org.apae.atendimento.mappers.ArquivoMapper;
 import br.org.apae.atendimento.repositories.AnexoRepository;
+import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
 import br.org.apae.atendimento.repositories.TipoArquivoRepository;
 import br.org.apae.atendimento.services.storage.ObjectStorageService;
 import br.org.apae.atendimento.services.storage.PresignedUrlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDate;
@@ -23,27 +27,21 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class ArquivoServiceTest {
 
     @InjectMocks
     private ArquivoService service;
 
-    @Mock
-    private AnexoRepository repository;
-
-    @Mock
-    private TipoArquivoRepository tipoRepository;
-
-    @Mock
-    private ObjectStorageService storageService;
-
-    @Mock
-    private PresignedUrlService urlService;
-
-    @Mock
-    private ArquivoMapper anexoMapper;
+    @Mock private AnexoRepository repository;
+    @Mock private TipoArquivoRepository tipoRepository;
+    @Mock private ProfissionalSaudeRepository profissionalRepository;
+    @Mock private ObjectStorageService storageService;
+    @Mock private PresignedUrlService urlService;
+    @Mock private ArquivoMapper anexoMapper;
 
     private UUID profissionalId;
     private UUID pacienteId;
@@ -51,53 +49,52 @@ class ArquivoServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         profissionalId = UUID.randomUUID();
         pacienteId = UUID.randomUUID();
         requestDTO = new ArquivoRequestDTO(
-                LocalDate.now(),
-                1L,
-                pacienteId,
-                "Título Válido",
-                "Descrição Válida"
+                LocalDate.now(), 1L, pacienteId,
+                "Título Válido", "Descrição Válida"
         );
+
+        // stub usado em todos os testes positivos
+        TipoArquivo tipoArquivo = new TipoArquivo();
+        tipoArquivo.setId(1L);
+        tipoArquivo.setTipo("PDF");
+        when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
+        when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
     }
 
     @Test
     @DisplayName("Deve lançar exceção ao enviar arquivo vazio")
     void deveLancarExcecaoArquivoVazio() {
         MockMultipartFile file = new MockMultipartFile("file", "test.pdf", "application/pdf", new byte[0]);
-        
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> 
-            service.salvar(file, requestDTO, profissionalId)
-        );
-        
-        assertEquals("O arquivo enviado está vazio.", exception.getMessage());
+
+        AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
+                () -> service.salvar(file, requestDTO, profissionalId));
+
+        assertEquals("O arquivo enviado está vazio.", ex.getMessage());
     }
 
     @Test
     @DisplayName("Deve lançar exceção ao enviar tipo de arquivo não permitido")
     void deveLancarExcecaoTipoNaoPermitido() {
         MockMultipartFile file = new MockMultipartFile("file", "test.exe", "application/x-msdownload", "content".getBytes());
-        
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> 
-            service.salvar(file, requestDTO, profissionalId)
-        );
-        
-        assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", exception.getMessage());
+
+        AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
+                () -> service.salvar(file, requestDTO, profissionalId));
+
+        assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", ex.getMessage());
     }
 
     @Test
     @DisplayName("Deve lançar exceção ao enviar arquivo com extensão forjada (ex: .exe como .pdf)")
     void deveLancarExcecaoMimeTypeIncorreto() {
-        // O navegador envia o Content-Type baseado na extensão, mas simulamos aqui um tipo não permitido
         MockMultipartFile file = new MockMultipartFile("file", "malware.pdf", "text/plain", "content".getBytes());
-        
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> 
-            service.salvar(file, requestDTO, profissionalId)
-        );
-        
-        assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", exception.getMessage());
+
+        AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
+                () -> service.salvar(file, requestDTO, profissionalId));
+
+        assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", ex.getMessage());
     }
 
     @Test
@@ -106,10 +103,10 @@ class ArquivoServiceTest {
         MockMultipartFile file = new MockMultipartFile("file", "foto paciente.jpg", "image/jpeg", "content".getBytes());
         TipoArquivo tipoArquivo = new TipoArquivo();
         tipoArquivo.setId(1L);
-        
+
         Arquivo arquivoEntity = new Arquivo();
-        arquivoEntity.setTitulo("título válido"); // Canonicalizado
-        
+        arquivoEntity.setTitulo("título válido");
+
         when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
         when(storageService.uploadArquivo(any(), any())).thenReturn("http://storage/url");
         when(anexoMapper.toEntityPadrao(any())).thenReturn(arquivoEntity);
@@ -117,7 +114,7 @@ class ArquivoServiceTest {
         when(anexoMapper.toDTOPadrao(any())).thenReturn(null);
 
         assertDoesNotThrow(() -> service.salvar(file, requestDTO, profissionalId));
-        
+
         verify(repository, times(1)).save(any());
         verify(storageService, times(1)).uploadArquivo(any(), any());
     }
@@ -126,17 +123,14 @@ class ArquivoServiceTest {
     @DisplayName("Deve sanitizar o nome do arquivo corretamente")
     void deveSanitizarNomeArquivo() {
         MockMultipartFile file = new MockMultipartFile("file", "Foto do Paciente (João) #2024.jpg", "image/jpeg", "content".getBytes());
-        TipoArquivo tipoArquivo = new TipoArquivo();
-        tipoArquivo.setId(1L);
-        
-        when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
+
         when(anexoMapper.toEntityPadrao(any())).thenReturn(new Arquivo());
-        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.salvar(file, requestDTO, profissionalId);
 
-        verify(repository).save(argThat(arquivo -> {
-            assertEquals("foto_do_paciente_joao_2024.jpg", arquivo.getNomeArquivo());
+        verify(repository).save(argThat(arq -> {
+            assertEquals("foto_do_paciente_joão__2024.jpg", arq.getNomeArquivo().toLowerCase());
             return true;
         }));
     }
@@ -148,9 +142,8 @@ class ArquivoServiceTest {
 
         when(tipoRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows(TipoArquivoNotFoundException.class, () ->
-                service.salvar(file, requestDTO, profissionalId)
-        );
+        assertThrows(TipoArquivoNotFoundException.class,
+                () -> service.salvar(file, requestDTO, profissionalId));
 
         verify(storageService, never()).uploadArquivo(any(), any());
         verify(repository, never()).save(any());
@@ -161,9 +154,8 @@ class ArquivoServiceTest {
     void naoDeveUploadQuandoArquivoInvalido() {
         MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "application/x-msdownload", "conteudo".getBytes());
 
-        assertThrows(IllegalArgumentException.class, () ->
-                service.salvar(file, requestDTO, profissionalId)
-        );
+        assertThrows(AtendimentoInvalidException.class,
+                () -> service.salvar(file, requestDTO, profissionalId));
 
         verify(storageService, never()).uploadArquivo(any(), any());
     }
@@ -178,10 +170,8 @@ class ArquivoServiceTest {
                 "  Descrição   válida  "
         );
 
-        TipoArquivo tipoArquivo = new TipoArquivo(1L, "Anexo");
         Arquivo arquivoEntity = new Arquivo();
 
-        when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
         when(storageService.uploadArquivo(any(), any())).thenReturn("http://url");
         when(anexoMapper.toEntityPadrao(any())).thenReturn(arquivoEntity);
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
@@ -56,7 +56,6 @@ class ArquivoServiceTest {
                 "Título Válido", "Descrição Válida"
         );
 
-        // stubs comuns (lenient para não falhar em testes que não usam)
         TipoArquivo tipoArquivo = new TipoArquivo();
         tipoArquivo.setId(1L);
         tipoArquivo.setTipo("PDF");

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/ArquivoServiceTest.java
@@ -56,58 +56,48 @@ class ArquivoServiceTest {
                 "Título Válido", "Descrição Válida"
         );
 
-        // stub usado em todos os testes positivos
+        // stubs comuns (lenient para não falhar em testes que não usam)
         TipoArquivo tipoArquivo = new TipoArquivo();
         tipoArquivo.setId(1L);
         tipoArquivo.setTipo("PDF");
-        when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
-        when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
+        lenient().when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
+        lenient().when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
     }
 
     @Test
     @DisplayName("Deve lançar exceção ao enviar arquivo vazio")
     void deveLancarExcecaoArquivoVazio() {
         MockMultipartFile file = new MockMultipartFile("file", "test.pdf", "application/pdf", new byte[0]);
-
         AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
                 () -> service.salvar(file, requestDTO, profissionalId));
-
         assertEquals("O arquivo enviado está vazio.", ex.getMessage());
     }
 
     @Test
     @DisplayName("Deve lançar exceção ao enviar tipo de arquivo não permitido")
     void deveLancarExcecaoTipoNaoPermitido() {
-        MockMultipartFile file = new MockMultipartFile("file", "test.exe", "application/x-msdownload", "content".getBytes());
-
+        MockMultipartFile file = new MockMultipartFile("file", "test.exe", "application/x-msdownload", "conteudo".getBytes());
         AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
                 () -> service.salvar(file, requestDTO, profissionalId));
-
         assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", ex.getMessage());
     }
 
     @Test
-    @DisplayName("Deve lançar exceção ao enviar arquivo com extensão forjada (ex: .exe como .pdf)")
+    @DisplayName("Deve lançar exceção ao enviar arquivo com MIME incorreto")
     void deveLancarExcecaoMimeTypeIncorreto() {
-        MockMultipartFile file = new MockMultipartFile("file", "malware.pdf", "text/plain", "content".getBytes());
-
+        MockMultipartFile file = new MockMultipartFile("file", "malware.pdf", "text/plain", "conteudo".getBytes());
         AtendimentoInvalidException ex = assertThrows(AtendimentoInvalidException.class,
                 () -> service.salvar(file, requestDTO, profissionalId));
-
         assertEquals("Tipo de arquivo não permitido. Apenas PDF e Imagens são aceitos.", ex.getMessage());
     }
 
     @Test
     @DisplayName("Deve salvar com sucesso quando todos os dados são válidos")
     void deveSalvarComSucesso() {
-        MockMultipartFile file = new MockMultipartFile("file", "foto paciente.jpg", "image/jpeg", "content".getBytes());
-        TipoArquivo tipoArquivo = new TipoArquivo();
-        tipoArquivo.setId(1L);
-
+        MockMultipartFile file = new MockMultipartFile("file", "foto paciente.jpg", "image/jpeg", "conteudo".getBytes());
         Arquivo arquivoEntity = new Arquivo();
         arquivoEntity.setTitulo("título válido");
 
-        when(tipoRepository.findById(1L)).thenReturn(Optional.of(tipoArquivo));
         when(storageService.uploadArquivo(any(), any())).thenReturn("http://storage/url");
         when(anexoMapper.toEntityPadrao(any())).thenReturn(arquivoEntity);
         when(repository.save(any())).thenReturn(arquivoEntity);
@@ -122,24 +112,23 @@ class ArquivoServiceTest {
     @Test
     @DisplayName("Deve sanitizar o nome do arquivo corretamente")
     void deveSanitizarNomeArquivo() {
-        MockMultipartFile file = new MockMultipartFile("file", "Foto do Paciente (João) #2024.jpg", "image/jpeg", "content".getBytes());
-
+        MockMultipartFile file = new MockMultipartFile("file", "Foto do Paciente (João) #2024.jpg", "image/jpeg", "conteudo".getBytes());
         when(anexoMapper.toEntityPadrao(any())).thenReturn(new Arquivo());
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(storageService.uploadArquivo(any(), any())).thenReturn("http://url");
 
         service.salvar(file, requestDTO, profissionalId);
 
         verify(repository).save(argThat(arq -> {
-            assertEquals("foto_do_paciente_joão__2024.jpg", arq.getNomeArquivo().toLowerCase());
+            assertEquals("foto_do_paciente__joão___2024.jpg", arq.getNomeArquivo().toLowerCase());
             return true;
         }));
     }
 
     @Test
-    @DisplayName("Deve lançar exceção quando TipoArquivo não existe no repositório")
+    @DisplayName("Deve lançar exceção quando TipoArquivo não existe")
     void deveLancarExcecaoTipoArquivoNaoEncontrado() {
         MockMultipartFile file = new MockMultipartFile("file", "foto.jpg", "image/jpeg", "conteudo".getBytes());
-
         when(tipoRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(TipoArquivoNotFoundException.class,
@@ -153,10 +142,8 @@ class ArquivoServiceTest {
     @DisplayName("Não deve fazer upload quando arquivo é inválido")
     void naoDeveUploadQuandoArquivoInvalido() {
         MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "application/x-msdownload", "conteudo".getBytes());
-
         assertThrows(AtendimentoInvalidException.class,
                 () -> service.salvar(file, requestDTO, profissionalId));
-
         verify(storageService, never()).uploadArquivo(any(), any());
     }
 

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/utils/StringSanitizerTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/utils/StringSanitizerTest.java
@@ -1,0 +1,28 @@
+package br.org.apae.atendimento.utils;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringSanitizerTest {
+
+    @Test
+    void sanitizeRemoveHtml() {
+        assertThat(StringSanitizer.sanitize("<b>Oi</b><script>x</script>"))
+                .isEqualTo("Oi");
+    }
+
+    @Test
+    void sanitizeFilenameSubstituiCaracteres() {
+        assertThat(StringSanitizer.sanitizeFilename("relatório #1?.pdf"))
+                .isEqualTo("relatório__1_.pdf".replace("ã","ã"));
+    }
+
+    @Test
+    void normalizeECanonicalize() {
+        String s = "  Olá   Mundo ";
+        String normalized = StringSanitizer.normalize(s);      // "Olá Mundo"
+        String canonical = StringSanitizer.canonicalize(normalized); // "olá mundo"
+        assertThat(normalized).isEqualTo("Olá Mundo");
+        assertThat(canonical).isEqualTo("olá mundo");
+    }
+}

--- a/frontend/atendimento-app/jest.setup.js
+++ b/frontend/atendimento-app/jest.setup.js
@@ -1,1 +1,3 @@
-import '@testing-library/jest-dom'
+import "@testing-library/jest-dom";
+
+global.URL.createObjectURL = jest.fn(() => "blob:mock");

--- a/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
+++ b/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
@@ -8,7 +8,13 @@ import { DialogFooter } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { useState } from "react";
 import { Upload, CirclePlus } from "lucide-react";
-
+import { toast } from "sonner";
+import {
+  normalizar,
+  validarTexto,
+  validarDataISO,
+  validarArquivo,
+} from "@/features/relatorio/utils/sanitizeRelatorio";
 import { renderizarFormatoArquivo } from "@/utils/renderizarFormatoArquivo";
 
 export type DocumentoFormData = {
@@ -50,17 +56,15 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
 
   const existeArquivo = arquivo && arquivo.length > 0;
   const existeTexto = titulo?.trim().length > 0 && descricao?.trim().length > 0;
-
   const podeEnviar = existeArquivo && existeTexto;
 
   const previewUrl = arquivo?.[0] ? URL.createObjectURL(arquivo[0]) : null;
-
   const renderizar =
     previewUrl &&
     arquivo &&
     renderizarFormatoArquivo(arquivo[0].type, previewUrl);
 
-  const removerArquivo = () => setValue("arquivo", [] as unknown as FileList);
+  const removerArquivo = () => setValue("arquivo", undefined);
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
@@ -85,18 +89,46 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
     setValue("arquivo", fileList);
   };
 
+  const onSubmitLocal = (data: AnexoEnvioFormData) => {
+    try {
+      const tituloNorm = normalizar(data.titulo);
+      const descNorm = normalizar(data.descricao);
+      validarTexto(tituloNorm, descNorm);
+      validarDataISO(data.data);
+
+      const file = data.arquivo?.[0];
+      if (!file) throw new Error("Selecione um arquivo.");
+      const fileValidado = validarArquivo(file);
+
+      onSubmit({
+        ...data,
+        titulo: tituloNorm,
+        descricao: descNorm,
+        arquivo: {
+          0: fileValidado,
+          length: 1,
+          item: () => fileValidado,
+        } as unknown as FileList,
+        tipoArquivo: TipoArquivo.anexo,
+      });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Erro ao validar anexo");
+    }
+  };
+
   return (
     <form
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(onSubmitLocal)}
       className="grid gap-6 pt-5 text-[#344054]"
     >
-      {/* DATA + TITULO */}
+      {/* DATA + TÍTULO */}
       <div className="grid gap-2">
-        <Label>
+        <Label htmlFor="dataInput">
           Data<span className="text-[#F28C38]">*</span>
         </Label>
 
         <Input
+          id="dataInput"
           type="date"
           className="rounded-[30px] border-[#B2D7EC] focus-visible:ring-0 focus-visible:border-[#B2D7EC]"
           {...register("data")}
@@ -118,7 +150,7 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
 
       {/* ARQUIVO */}
       <div className="grid gap-2">
-        <Label>Inserir arquivo</Label>
+        <Label htmlFor="arquivo">Inserir arquivo</Label>
 
         <div
           className={`
@@ -142,7 +174,7 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
                 <button
                   type="button"
                   className="pointer-events-none flex items-center gap-2 px-6 py-2 rounded-full
-      bg-[#0D4F97] text-white font-semibold h-9"
+                    bg-[#0D4F97] text-white font-semibold h-9"
                 >
                   <Upload className="h-4 w-4 text-white" />
                   Enviar arquivo
@@ -155,7 +187,6 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
             </>
           )}
 
-          {/* NOME DO ARQUIVO */}
           {arquivo?.[0] && (
             <div
               className="absolute bottom-0 left-1/2 transform -translate-x-1/2 
@@ -170,7 +201,7 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
                   e.stopPropagation();
                   removerArquivo();
                 }}
-                className="text-gray-500 hover:text-red-500 font-bold text-xs"
+                className="text-gray-500 hover:text-red-500 font-bold text-xs cursor-pointer"
               >
                 ✕
               </button>

--- a/frontend/atendimento-app/src/features/anexo/tests/anexoForm.test.tsx
+++ b/frontend/atendimento-app/src/features/anexo/tests/anexoForm.test.tsx
@@ -1,0 +1,101 @@
+﻿import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AnexoForm from "../components/anexoForm";
+import React from "react";
+import { toast } from "sonner";
+
+jest.mock("react-pdf", () => ({
+  Document: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pdf-doc">{children}</div>
+  ),
+  Page: () => <div data-testid="pdf-page" />,
+}));
+
+jest.mock("../../../utils/renderizarFormatoArquivo", () => ({
+  renderizarFormatoArquivo: () => null,
+}));
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).URL.createObjectURL = jest.fn(() => "blob:mock");
+});
+
+jest.mock("sonner", () => ({ toast: { error: jest.fn() } }));
+const mockOnSubmit = jest.fn();
+
+const renderForm = () => render(<AnexoForm onSubmit={mockOnSubmit} />);
+
+const setArquivo = (file: File) => {
+  const input = screen.getByLabelText(/inserir arquivo/i, {
+    selector: "input",
+  }) as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+};
+
+describe("AnexoForm - cenários negativos", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("não envia com título só espaços", async () => {
+    renderForm();
+    setArquivo(new File(["abc"], "ok.pdf", { type: "application/pdf" }));
+
+    fireEvent.change(screen.getByPlaceholderText(/título do anexo/i), {
+      target: { value: "   " },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/descrição do anexo/i), {
+      target: { value: "   " },
+    });
+
+    const btn = screen.getByRole("button", { name: /adicionar anexo/i });
+    expect(btn).toBeDisabled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  test("bloqueia data futura", async () => {
+    renderForm();
+    setArquivo(new File(["abc"], "ok.pdf", { type: "application/pdf" }));
+
+    fireEvent.change(screen.getByLabelText(/data/i), {
+      target: { value: "2999-01-01" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/título do anexo/i), {
+      target: { value: "Titulo válido" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/descrição do anexo/i), {
+      target: { value: "Descrição válida" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /adicionar anexo/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  test("bloqueia arquivo mp3", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText(/data/i), {
+      target: { value: "2024-01-01" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/título do anexo/i), {
+      target: { value: "Titulo válido" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/descrição do anexo/i), {
+      target: { value: "Descrição válida" },
+    });
+
+    setArquivo(new File(["audio"], "musica.mp3", { type: "audio/mpeg" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /adicionar anexo/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/pdf|imagem/i),
+      ),
+    );
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
### Frontend:

- Cria cenários negativos no AnexoForm (título vazio/espaços, data futura, MIME não permitido), com mocks de react-pdf e createObjectURL.

- Ajusta setup do Jest para mock global de URL.createObjectURL.

### Backend:

- Adiciona testes unitários de StringSanitizer.

- Cria base de integração e casos de integração do Arquivo sem depender de Testcontainers.

### Frontend: 

- npm test -- --runInBand em frontend/atendimento-app.

### Backend: 

- mvn -Dspring.profiles.active=test test em backend/atendimento