### PR TITLE
fix: corrigir fluxo de criação/listagem de atendimentos e adicionar testes de integração (#277)

### DIFF
--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/AtendimentoRequestDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/AtendimentoRequestDTO.java
@@ -1,16 +1,12 @@
 package br.org.apae.atendimento.dtos.request;
 
-import br.org.apae.atendimento.entities.Topico;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 public record AtendimentoRequestDTO(
@@ -20,7 +16,7 @@ public record AtendimentoRequestDTO(
 
         @NotEmpty(message = "O relatório deve conter pelo menos um tópico")
         @Valid
-        Set<Topico> relatorio,
+        List<TopicoRequestDTO> relatorio,
 
         @NotNull(message = "A data do atendimento é obrigatória")
         LocalDate data,

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/TopicoRequestDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/request/TopicoRequestDTO.java
@@ -1,0 +1,11 @@
+package br.org.apae.atendimento.dtos.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TopicoRequestDTO(
+        @NotBlank(message = "O título do tópico é obrigatório")
+        String titulo,
+        @NotBlank(message = "A descrição do tópico é obrigatória")
+        String descricao
+) {
+}

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AtendimentoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AtendimentoResponseDTO.java
@@ -1,14 +1,13 @@
 package br.org.apae.atendimento.dtos.response;
-import br.org.apae.atendimento.entities.Topico;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 public record AtendimentoResponseDTO(
     UUID id,
-    Set<Topico> relatorio,
+    List<TopicoResponseDTO> relatorio,
     LocalDate data,
     LocalTime hora,
     Long numeracao

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/TopicoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/TopicoResponseDTO.java
@@ -1,0 +1,10 @@
+package br.org.apae.atendimento.dtos.response;
+
+import java.util.UUID;
+
+public record TopicoResponseDTO(
+        UUID id,
+        String titulo,
+        String descricao
+) {
+}

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
@@ -1,26 +1,27 @@
 package br.org.apae.atendimento.entities;
 
 import jakarta.persistence.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Entity
 @Table(name = "atendimento")
+@Getter
+@Setter
+@NoArgsConstructor
 public class Atendimento {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "atendimeto_id")
-    private Set<Topico> relatorio = new HashSet<>();
+    @OneToMany(mappedBy = "atendimento", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderColumn(name = "ordem")
+    private List<Topico> relatorio = new ArrayList<>();
 
     @Column(name = "data_atendimento")
     private LocalDateTime dataAtendimento;
@@ -36,53 +37,4 @@ public class Atendimento {
     @JoinColumn(name = "profissional_id")
     private ProfissionalSaude profissional;
 
-    public Atendimento() {}
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public Set<Topico> getRelatorio() {
-        return relatorio;
-    }
-
-    public void setRelatorio(Set<Topico> relatorio) {
-        this.relatorio = relatorio;
-    }
-
-    public LocalDateTime getDataAtendimento() {
-        return dataAtendimento;
-    }
-
-    public void setDataAtendimento(LocalDateTime dataAtendimento) {
-        this.dataAtendimento = dataAtendimento;
-    }
-
-    public Paciente getPaciente() {
-        return paciente;
-    }
-
-    public void setPaciente(Paciente paciente) {
-        this.paciente = paciente;
-    }
-
-    public ProfissionalSaude getProfissional() {
-        return profissional;
-    }
-
-    public void setProfissional(ProfissionalSaude profissional) {
-        this.profissional = profissional;
-    }
-
-    public Long getNumeracao() {
-        return numeracao;
-    }
-
-    public void setNumeracao(Long numeracao) {
-        this.numeracao = numeracao;
-    }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Topico.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Topico.java
@@ -28,4 +28,7 @@ public class Topico {
     @Column(nullable = false)
     private String descricao;
 
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "atendimento_id", nullable = false)
+    private Atendimento atendimento;
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AtendimentoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AtendimentoMapper.java
@@ -1,6 +1,8 @@
 package br.org.apae.atendimento.mappers;
 
 import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
+import br.org.apae.atendimento.dtos.response.TopicoResponseDTO;
+import br.org.apae.atendimento.entities.Topico;
 import br.org.apae.atendimento.repositories.PacienteRepository;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +11,10 @@ import br.org.apae.atendimento.entities.Atendimento;
 import br.org.apae.atendimento.entities.Paciente;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class AtendimentoMapper extends AbstractMapper<Atendimento, AtendimentoRequestDTO, AtendimentoResponseDTO> {
@@ -29,16 +35,31 @@ public class AtendimentoMapper extends AbstractMapper<Atendimento, AtendimentoRe
 
         atendimento.setDataAtendimento(dataAtendimento);
         atendimento.setPaciente(paciente);
-        atendimento.setRelatorio(dtoPadraoAtendimento.relatorio());
+
+        List<Topico> relatorio = dtoPadraoAtendimento.relatorio().stream()
+                .map(t -> {
+                    Topico topico = new Topico();
+                    topico.setTitulo(t.titulo());
+                    topico.setDescricao(t.descricao());
+                    topico.setAtendimento(atendimento);
+                    return topico;
+                })
+                .collect(Collectors.toList());
+
+        atendimento.setRelatorio(relatorio);
 
         return atendimento;
     }
 
     @Override
     public AtendimentoResponseDTO toDTOPadrao(Atendimento entidadePadraoAtendimento) {
+        List<TopicoResponseDTO> relatorio = entidadePadraoAtendimento.getRelatorio().stream()
+                .map(t -> new TopicoResponseDTO(t.getId(), t.getTitulo(),t.getDescricao()))
+                .collect(Collectors.toList());
+
         return new AtendimentoResponseDTO(
                 entidadePadraoAtendimento.getId(),
-                entidadePadraoAtendimento.getRelatorio(),
+                relatorio,
                 entidadePadraoAtendimento.getDataAtendimento().toLocalDate(),
                 entidadePadraoAtendimento.getDataAtendimento().toLocalTime(),
                 entidadePadraoAtendimento.getNumeracao());

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
@@ -8,18 +8,42 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> {
     List<Atendimento> findByPacienteIdAndProfissionalIdOrderByDataAtendimento(UUID pacienteId, UUID profissionalId);
 
-    @Query("SELECT MAX(a.numeracao) " +
-            "FROM Agendamento a " +
-            "WHERE MONTH(a.dataHora) = :mes " +
-            "AND YEAR(a.dataHora) = :ano " +
-            "AND a.profissional.id = :profissionalId")
+    @Query("""
+        SELECT MAX(a.numeracao)
+        FROM Atendimento a
+        WHERE MONTH(a.dataAtendimento) = :mes
+          AND YEAR(a.dataAtendimento) = :ano
+          AND a.profissional.id = :profissionalId
+    """)
     Long findMaxNumeracaoByMesAndAno(@Param("mes") int mes, @Param("ano") int ano, @Param("profissionalId") UUID profissionalId);
+
+    @Query("""
+        SELECT DISTINCT a
+        FROM Atendimento a
+        LEFT JOIN FETCH a.relatorio
+        WHERE a.paciente.id = :pacienteid
+            AND a.profissional.id = :profissionalid
+        ORDER BY a.dataAtendimento
+    """)
+    List<Atendimento> findByPacienteIdAndProfissionalIdComRelatorio(
+            @Param("pacienteid") UUID pacienteId,
+            @Param("profissionalid") UUID profissionalId
+    );
+
+    @Query("""
+        SELECT a
+        FROM Atendimento a
+        LEFT JOIN FETCH a.relatorio
+        WHERE a.id = :atendimentoId
+    """)
+    Optional<Atendimento> findByIdComRelatorio(@Param("atendimentoId") UUID atendimentoId);
 
     @Query("""
         SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
@@ -4,11 +4,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
+import br.org.apae.atendimento.dtos.request.TopicoRequestDTO;
 import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
 import br.org.apae.atendimento.dtos.response.MesAnoAtendimentoResponseDTO;
 import br.org.apae.atendimento.entities.Agendamento;
@@ -24,6 +24,7 @@ import br.org.apae.atendimento.mappers.AtendimentoMapper;
 import br.org.apae.atendimento.repositories.AtendimentoRepository;
 import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AtendimentoService {
@@ -48,26 +49,28 @@ public class AtendimentoService {
     }
 
     public AtendimentoResponseDTO addAtendimento(AtendimentoRequestDTO atendimentoRequestDTO, UUID profissionalId) {
+        if (!pacienteService.existeRelacao(atendimentoRequestDTO.pacienteId(), profissionalId)) {
+            throw new RelacaoInvalidException("Você não tem permissão para criar atendimentos deste paciente.");
+        }
+
         if (repository.existsByProfissionalIdAndDataAtendimento(
                 profissionalId,
-                LocalDateTime.of(atendimentoRequestDTO.data(), atendimentoRequestDTO.hora()))) {
+                LocalDateTime.of(atendimentoRequestDTO.data(), atendimentoRequestDTO.hora())
+        )) {
             throw new AtendimentoInvalidException("Já existe um atendimento neste horário.");
         }
 
         Atendimento dadosConvertidos = atendimentoMapper.toEntityPadrao(atendimentoRequestDTO);
-
         ProfissionalSaude profissional = profissionalRepository.getReferenceById(profissionalId);
         dadosConvertidos.setProfissional(profissional);
 
-        verificarRelatorio(dadosConvertidos.getRelatorio());
+        verificarRelatorio(atendimentoRequestDTO.relatorio());
 
-        dadosConvertidos.setNumeracao(gerarProximaNumeracao(atendimentoRequestDTO.data(),
-                profissionalId));
+        dadosConvertidos.setNumeracao(gerarProximaNumeracao(profissionalId, atendimentoRequestDTO.data()));
 
         Atendimento dadosPersistidos = repository.save(dadosConvertidos);
         try {
-            tratarAgendamento(atendimentoRequestDTO.pacienteId(), atendimentoRequestDTO.data(),
-                    dadosPersistidos.getNumeracao());
+            tratarAgendamento(atendimentoRequestDTO.pacienteId(), atendimentoRequestDTO.data(), dadosPersistidos.getNumeracao());
         } catch (AgendamentoNotFoundException e) {
             // Ignora a exceção propositalmente.
             // Isso acontece quando é um atendimento de "encaixe" sem agendamento prévio.
@@ -77,12 +80,12 @@ public class AtendimentoService {
 
     }
 
-    private void verificarRelatorio(Set<Topico> relatorio) {
+    private void verificarRelatorio(List<TopicoRequestDTO> relatorio) {
         if (relatorio == null || relatorio.isEmpty()) {
             throw new AtendimentoInvalidException("Atendimento sem qualquer tópico");
         }
-        for (Topico topico : relatorio) {
-            if (topico.getTitulo().isEmpty() || topico.getDescricao().isEmpty()) {
+        for (TopicoRequestDTO topico : relatorio) {
+            if (topico.titulo().isEmpty() || topico.descricao().isEmpty()) {
                 throw new TopicoInvalidException("Topico sem titulo ou descrição");
             }
         }
@@ -98,7 +101,7 @@ public class AtendimentoService {
     public List<MesAnoAtendimentoResponseDTO> getAtendimentosAgrupadosPorMes(UUID pacienteId, UUID profissionalId) {
 
         List<Atendimento> atendimentos = repository
-                .findByPacienteIdAndProfissionalIdOrderByDataAtendimento(pacienteId, profissionalId);
+                .findByPacienteIdAndProfissionalIdComRelatorio(pacienteId, profissionalId);
 
         return atendimentos.stream()
                 .collect(Collectors.groupingBy(
@@ -117,34 +120,41 @@ public class AtendimentoService {
         repository.deleteById(atendimentoId);
     }
 
-    public Long gerarProximaNumeracao(LocalDate data, UUID profissionalId) {
+    public Long gerarProximaNumeracao(UUID profissionalId, LocalDate data) {
         Long maiorNumeracao = repository.findMaxNumeracaoByMesAndAno(
-                data.getMonthValue(), data.getYear(), profissionalId);
+                data.getMonthValue(),
+                data.getYear(),
+                profissionalId);
 
         long numeracaoAtual = (maiorNumeracao != null) ? maiorNumeracao : 0L;
 
         return numeracaoAtual + 1;
     }
 
+    @Transactional(readOnly = false)
     public AtendimentoResponseDTO editar(AtendimentoRequestDTO requestDTO, UUID atendimentoId, UUID profissionalId) {
         if (!pacienteService.existeRelacao(requestDTO.pacienteId(), profissionalId)) {
             throw new RelacaoInvalidException("Você não tem permissão para editar atendimentos deste paciente.");
         }
 
-        Atendimento atendimento = repository.findById(atendimentoId)
+        Atendimento atendimento = repository.findByIdComRelatorio(atendimentoId)
                 .orElseThrow(() -> new AtendimentoNotFoundException("O atendimento que deseja editar não foi encontrado."));
         verificarRelatorio(requestDTO.relatorio());
 
         atendimento.getRelatorio().clear();
-        atendimento.getRelatorio().addAll(requestDTO.relatorio());
+        requestDTO.relatorio().forEach(t -> {
+            Topico topico = new Topico();
+            topico.setTitulo(t.titulo());
+            topico.setDescricao(t.descricao());
+            topico.setAtendimento(atendimento);
+            atendimento.getRelatorio().add(topico);
+        });
 
-        if (!requestDTO.data().equals(atendimento.getDataAtendimento().toLocalDate())) {
-            atendimento.setNumeracao(gerarProximaNumeracao(
-                    requestDTO.data(), profissionalId));
+        if (!requestDTO.data().equals(atendimento.getDataAtendimento().toLocalDate())
+                || !requestDTO.hora().equals(atendimento.getDataAtendimento().toLocalTime())) {
             atendimento.setDataAtendimento(LocalDateTime.of(requestDTO.data(), requestDTO.hora()));
         }
 
         return atendimentoMapper.toDTOPadrao(repository.save(atendimento));
-
     }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ProfissionalSaudeService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ProfissionalSaudeService.java
@@ -58,9 +58,9 @@ public class ProfissionalSaudeService {
     }
 
     public List<PacienteResponseDTO> getPacientesDoProfissional(UUID id) {
-        ProfissionalSaude profissionalSaude = getProfissionalById(id);
+        List<Paciente> pacientes = pacienteRepository.findByProfissionais_Id(id);
 
-        return profissionalSaude.getPacientes().stream()
+        return pacientes.stream()
                 .map(paciente -> {
                     PacienteResponseDTO dtoSemFoto = pacienteMapper.toDTOPadrao(paciente);
                     String url = urlService.gerarUrlPreAssinada(FOTO_PATH + paciente.getId());

--- a/backend/atendimento/src/main/resources/schema.sql
+++ b/backend/atendimento/src/main/resources/schema.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS topico CASCADE;
+DROP TABLE IF EXISTS atendimento CASCADE;
 DROP TABLE IF EXISTS profissional_paciente CASCADE;
 DROP TABLE IF EXISTS vw_pacientes CASCADE;
 DROP TABLE IF EXISTS vw_profissionais CASCADE;
@@ -32,4 +34,20 @@ CREATE TABLE IF NOT EXISTS profissional_paciente (
     profissional_id UUID REFERENCES vw_profissionais(id),
     paciente_id UUID REFERENCES vw_pacientes(id),
     PRIMARY KEY (profissional_id, paciente_id)
+);
+
+CREATE TABLE IF NOT EXISTS atendimento (
+    id UUID PRIMARY KEY,
+    data_atendimento TIMESTAMP NOT NULL,
+    numeracao BIGINT,
+    paciente_id UUID NOT NULL REFERENCES vw_pacientes(id),
+    profissional_id UUID NOT NULL REFERENCES vw_profissionais(id)
+);
+
+CREATE TABLE IF NOT EXISTS topico (
+     id UUID PRIMARY KEY,
+     titulo VARCHAR(255) NOT NULL,
+     descricao TEXT NOT NULL,
+     ordem INTEGER,
+     atendimento_id UUID NOT NULL REFERENCES atendimento(id)
 );

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/controllers/AtendimentoControllerIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/controllers/AtendimentoControllerIntegrationTest.java
@@ -1,0 +1,51 @@
+package br.org.apae.atendimento.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class AtendimentoControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Deve criar e listar atendimentos para paciente vinculado ao profissional autenticado")
+    void deveCriarEListarAtendimentosComProfissionalAutenticado() throws Exception {
+        // IDs fixos do data-test.sql
+        String pacienteId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+        String payload = """
+        {
+          "pacienteId": "%s",
+          "relatorio": [{"titulo": "Titulo 1", "descricao": "Descricao 1"}],
+          "data": "10-05-2026",
+          "hora": "10:00"
+        }
+        """.formatted(pacienteId);
+
+        // POST /atendimentos
+        mockMvc.perform(
+                post("/atendimentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload)
+        ).andExpect(status().isCreated());
+
+        // GET /atendimentos/{pacienteId}
+        mockMvc.perform(
+                get("/atendimentos/{pacienteId}", pacienteId)
+        ).andExpect(status().isOk());
+    }
+}

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceIntegrationTest.java
@@ -1,0 +1,102 @@
+package br.org.apae.atendimento.services;
+
+import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
+import br.org.apae.atendimento.dtos.request.TopicoRequestDTO;
+import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
+import br.org.apae.atendimento.dtos.response.MesAnoAtendimentoResponseDTO;
+import br.org.apae.atendimento.entities.Paciente;
+import br.org.apae.atendimento.entities.ProfissionalSaude;
+import br.org.apae.atendimento.repositories.AtendimentoRepository;
+import br.org.apae.atendimento.repositories.PacienteRepository;
+import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AtendimentoServiceIntegrationTest {
+
+    @Autowired
+    private AtendimentoService atendimentoService;
+
+    @Autowired
+    private AtendimentoRepository atendimentoRepository;
+
+    @Autowired
+    private PacienteRepository pacienteRepository;
+
+    @Autowired
+    private ProfissionalSaudeRepository profissionalSaudeRepository;
+
+    @Test
+    @DisplayName("Deve criar, listar e editar atendimentos mantendo numeração por mês/ano")
+    void deveCriarListarEEditarComNumeracaoPorMesEAno() {
+        ProfissionalSaude profissional = profissionalSaudeRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Nenhum profissional carregado no data-test.sql"));
+
+        Paciente paciente = pacienteRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Nenhum paciente carregado no data-test.sql"));
+
+        if (!pacienteRepository.existeRelacao(paciente.getId(), profissional.getId())) {
+            fail("O paciente de teste precisa estar vinculado ao profissional no data-test.sql");
+        }
+
+        AtendimentoRequestDTO request1 = new AtendimentoRequestDTO(
+                paciente.getId(),
+                List.of(new TopicoRequestDTO("Título 1", "Descrição 1")),
+                LocalDate.of(2026, 5, 10),
+                LocalTime.of(10, 0)
+        );
+
+        AtendimentoRequestDTO request2 = new AtendimentoRequestDTO(
+                paciente.getId(),
+                List.of(new TopicoRequestDTO("Título 2", "Descrição 2")),
+                LocalDate.of(2026, 5, 11),
+                LocalTime.of(11, 0)
+        );
+
+        AtendimentoResponseDTO created1 = atendimentoService.addAtendimento(request1, profissional.getId());
+        AtendimentoResponseDTO created2 = atendimentoService.addAtendimento(request2, profissional.getId());
+
+        assertNotNull(created1);
+        assertNotNull(created2);
+        assertEquals(1L, created1.numeracao());
+        assertEquals(2L, created2.numeracao());
+
+        AtendimentoRequestDTO editRequest = new AtendimentoRequestDTO(
+                paciente.getId(),
+                List.of(new TopicoRequestDTO("Título editado", "Descrição editada")),
+                LocalDate.of(2026, 5, 15),
+                LocalTime.of(14, 0)
+        );
+
+        AtendimentoResponseDTO edited = atendimentoService.editar(
+                editRequest,
+                created1.id(),
+                profissional.getId()
+        );
+
+        assertNotNull(edited);
+        assertEquals(created1.numeracao(), edited.numeracao());
+
+        List<MesAnoAtendimentoResponseDTO> agrupados =
+                atendimentoService.getAtendimentosAgrupadosPorMes(paciente.getId(), profissional.getId());
+
+        assertFalse(agrupados.isEmpty());
+        assertTrue(agrupados.stream().anyMatch(g -> g.mesAno().equals(YearMonth.of(2026, 5))));
+    }
+}

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceTest.java
@@ -1,0 +1,231 @@
+package br.org.apae.atendimento.services;
+
+import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
+import br.org.apae.atendimento.dtos.request.TopicoRequestDTO;
+import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
+import br.org.apae.atendimento.dtos.response.MesAnoAtendimentoResponseDTO;
+import br.org.apae.atendimento.entities.Agendamento;
+import br.org.apae.atendimento.entities.Atendimento;
+import br.org.apae.atendimento.entities.ProfissionalSaude;
+import br.org.apae.atendimento.entities.Topico;
+import br.org.apae.atendimento.exceptions.invalid.AtendimentoInvalidException;
+import br.org.apae.atendimento.exceptions.invalid.RelacaoInvalidException;
+import br.org.apae.atendimento.exceptions.notfound.AgendamentoNotFoundException;
+import br.org.apae.atendimento.exceptions.notfound.AtendimentoNotFoundException;
+import br.org.apae.atendimento.mappers.AtendimentoMapper;
+import br.org.apae.atendimento.repositories.AtendimentoRepository;
+import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AtendimentoServiceTest {
+
+    @InjectMocks
+    private AtendimentoService service;
+
+    @Mock
+    private AtendimentoRepository repository;
+
+    @Mock
+    private ProfissionalSaudeRepository profissionalRepository;
+
+    @Mock
+    private AgendamentoService agendamentoService;
+
+    @Mock
+    private AtendimentoMapper atendimentoMapper;
+
+    @Mock
+    private PacienteService pacienteService;
+
+    private UUID profissionalId;
+    private UUID pacienteId;
+    private AtendimentoRequestDTO requestDTO;
+
+    @BeforeEach
+    void setUp() {
+        profissionalId = UUID.randomUUID();
+        pacienteId = UUID.randomUUID();
+
+        requestDTO = new AtendimentoRequestDTO(
+                pacienteId,
+                List.of(new TopicoRequestDTO("Titulo", "Descricao")),
+                LocalDate.now(),
+                LocalTime.of(10, 0)
+        );
+    }
+
+    @Test
+    @DisplayName("Deve criar atendimento com numeracao global incrementada")
+    void deveCriarAtendimentoComNumeracaoGlobal() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.existsByProfissionalIdAndDataAtendimento(any(), any())).thenReturn(false);
+        when(repository.findMaxNumeracaoByMesAndAno(LocalDate.now().getMonthValue(), LocalDate.now().getYear(), profissionalId)).thenReturn(1L);
+        when(atendimentoMapper.toEntityPadrao(requestDTO)).thenReturn(new Atendimento());
+        when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
+
+        Atendimento entity = new Atendimento();
+        when(repository.save(any())).thenReturn(entity);
+        when(atendimentoMapper.toDTOPadrao(entity)).thenReturn(mock(AtendimentoResponseDTO.class));
+
+        when(agendamentoService.buscarAgendamentoPorDataEPaciente(any(), any()))
+                .thenReturn(new Agendamento());
+
+        AtendimentoResponseDTO response = service.addAtendimento(requestDTO, profissionalId);
+
+        assertNotNull(response);
+        verify(repository).findMaxNumeracaoByMesAndAno(LocalDate.now().getMonthValue(), LocalDate.now().getYear(), profissionalId);
+        verify(repository).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar erro quando profissional não possui vínculo com paciente")
+    void deveLancarErroQuandoSemRelacao() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(false);
+
+        assertThrows(RelacaoInvalidException.class,
+                () -> service.addAtendimento(requestDTO, profissionalId));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar erro quando já existe atendimento no horário")
+    void deveLancarErroQuandoHorarioConflitante() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.existsByProfissionalIdAndDataAtendimento(any(), any())).thenReturn(true);
+
+        assertThrows(AtendimentoInvalidException.class,
+                () -> service.addAtendimento(requestDTO, profissionalId));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar erro quando relatorio estiver vazio")
+    void deveLancarErroQuandoRelatorioVazio() {
+        AtendimentoRequestDTO dtoSemRelatorio = new AtendimentoRequestDTO(
+                pacienteId,
+                List.of(),
+                LocalDate.now(),
+                LocalTime.of(10, 0)
+        );
+
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.existsByProfissionalIdAndDataAtendimento(any(), any())).thenReturn(false);
+        when(atendimentoMapper.toEntityPadrao(dtoSemRelatorio)).thenReturn(new Atendimento());
+
+        assertThrows(AtendimentoInvalidException.class,
+                () -> service.addAtendimento(dtoSemRelatorio, profissionalId));
+
+        verify(atendimentoMapper).toEntityPadrao(dtoSemRelatorio);
+    }
+
+    @Test
+    @DisplayName("Deve editar atendimento e substituir relatorio")
+    void deveEditarAtendimento() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+
+        Atendimento atendimento = new Atendimento();
+        atendimento.setDataAtendimento(LocalDateTime.now());
+        atendimento.getRelatorio().add(new Topico());
+
+        when(repository.findByIdComRelatorio(any())).thenReturn(Optional.of(atendimento));
+        when(repository.save(atendimento)).thenReturn(atendimento);
+        when(atendimentoMapper.toDTOPadrao(atendimento)).thenReturn(mock(AtendimentoResponseDTO.class));
+
+        AtendimentoResponseDTO response = service.editar(requestDTO, UUID.randomUUID(), profissionalId);
+
+        assertNotNull(response);
+        assertFalse(atendimento.getRelatorio().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Deve lançar erro ao editar atendimento inexistente")
+    void deveLancarErroQuandoAtendimentoNaoEncontrado() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.findByIdComRelatorio(any())).thenReturn(Optional.empty());
+
+        assertThrows(AtendimentoNotFoundException.class,
+                () -> service.editar(requestDTO, UUID.randomUUID(), profissionalId));
+    }
+
+    @Test
+    @DisplayName("Deve agrupar atendimentos por mês")
+    void deveAgruparAtendimentosPorMes() {
+        Atendimento a1 = new Atendimento();
+        a1.setDataAtendimento(LocalDateTime.of(2026, 5, 10, 10, 0));
+        Atendimento a2 = new Atendimento();
+        a2.setDataAtendimento(LocalDateTime.of(2026, 6, 5, 11, 0));
+
+        when(repository.findByPacienteIdAndProfissionalIdComRelatorio(pacienteId, profissionalId))
+                .thenReturn(List.of(a1, a2));
+        when(atendimentoMapper.toDTOPadrao(any())).thenReturn(mock(AtendimentoResponseDTO.class));
+
+        List<MesAnoAtendimentoResponseDTO> result =
+                service.getAtendimentosAgrupadosPorMes(pacienteId, profissionalId);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(r -> r.mesAno().equals(YearMonth.of(2026, 5))));
+        assertTrue(result.stream().anyMatch(r -> r.mesAno().equals(YearMonth.of(2026, 6))));
+    }
+
+    @Test
+    @DisplayName("Deve ignorar AgendamentoNotFoundException ao criar atendimento")
+    void deveIgnorarAgendamentoNotFoundException() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.existsByProfissionalIdAndDataAtendimento(any(), any())).thenReturn(false);
+        when(repository.findMaxNumeracaoByMesAndAno(LocalDate.now().getMonthValue(), LocalDate.now().getYear(), profissionalId)).thenReturn(0L);
+        when(atendimentoMapper.toEntityPadrao(requestDTO)).thenReturn(new Atendimento());
+        when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
+
+        Atendimento entity = new Atendimento();
+        when(repository.save(any())).thenReturn(entity);
+        when(atendimentoMapper.toDTOPadrao(entity)).thenReturn(mock(AtendimentoResponseDTO.class));
+
+        doThrow(new AgendamentoNotFoundException("nao encontrado"))
+                .when(agendamentoService)
+                .buscarAgendamentoPorDataEPaciente(any(), any());
+
+        assertDoesNotThrow(() -> service.addAtendimento(requestDTO, profissionalId));
+    }
+
+    @Test
+    @DisplayName("Deve setar numeracao correta ao salvar atendimento")
+    void deveSetarNumeracaoCorretaAoSalvar() {
+        when(pacienteService.existeRelacao(pacienteId, profissionalId)).thenReturn(true);
+        when(repository.existsByProfissionalIdAndDataAtendimento(any(), any())).thenReturn(false);
+        when(repository.findMaxNumeracaoByMesAndAno(LocalDate.now().getMonthValue(), LocalDate.now().getYear(), profissionalId)).thenReturn(5L);
+
+        Atendimento entity = new Atendimento();
+        when(atendimentoMapper.toEntityPadrao(requestDTO)).thenReturn(entity);
+        when(profissionalRepository.getReferenceById(profissionalId)).thenReturn(new ProfissionalSaude());
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(atendimentoMapper.toDTOPadrao(any())).thenReturn(mock(AtendimentoResponseDTO.class));
+
+        when(agendamentoService.buscarAgendamentoPorDataEPaciente(any(), any()))
+                .thenReturn(new Agendamento());
+
+        service.addAtendimento(requestDTO, profissionalId);
+
+        assertEquals(6L, entity.getNumeracao());
+    }
+}


### PR DESCRIPTION
##  Contexto
A Tela de Atendimento apresentava falhas na criação e listagem de atendimentos vinculados ao profissional autenticado, afetando o fluxo principal do sistema. O problema envolvia carregamento incompleto de dados relacionados e inconsistências na numeração.

## Objetivo
Garantir que a criação e a listagem de atendimentos funcionem corretamente para pacientes vinculados ao profissional logado, sem erros de autenticação ou de consulta, e com persistência correta dos dados.

##  Problema de lazy loading (causa raiz)
A listagem retornava atendimentos com `relatorio` configurado como lazy. 
Ao serializar a resposta fora do contexto transacional, o Hibernate não conseguia inicializar a coleção, gerando erros (lazy initialization) ou dados incompletos.

##  Como foi corrigido
Foi ajustada a consulta do repositório para carregar o `relatorio` com `JOIN FETCH`, garantindo que a coleção seja carregada antes da serialização.  
O service passou a usar essa query na listagem agrupada, evitando o acesso lazy fora da sessão.

##  O que foi feito
- Ajustado o carregamento de dados relacionados para evitar problemas de lazy loading durante a listagem.
- Corrigida a regra de numeração por mês/ano, garantindo incremento correto e preservação da numeração ao editar.
- Corrigido erro de cálculo de mês em consultas relacionadas a atendimento.
- Adicionados testes de integração para validar o fluxo completo:
  - criação de atendimento com profissional autenticado;
  - listagem filtrada por profissional e paciente.

##  Testes executados
- `AtendimentoServiceTest`
- `AtendimentoServiceIntegrationTest`
- `AtendimentoControllerIntegrationTest`

## Critérios de aceite atendidos
- Criação de atendimento permitida para paciente vinculado ao profissional logado.
- Listagem retornando atendimentos corretamente filtrados pelo profissional autenticado.
- Sem erros no backend durante criação ou consulta.
- Persistência validada em ambiente de teste.
- Sem exceções relacionadas a autenticação ou joins inválidos.

##
<img width="1918" height="912" alt="image" src="https://github.com/user-attachments/assets/403e97c8-9ee6-47d2-95a2-3c23d78bb278" />
