### PR TITLE
feat/280: adicionar exclusao de atendimentos

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -16,11 +16,18 @@ jobs:
       - name: Baixar repositório
         uses: actions/checkout@v4
 
-      - name: Instalar PNPM
-        uses: pnpm/action-setup@v3
+      - name: Configurar Node
+        uses: actions/setup-node@v4
         with:
-          version: latest
-          cache: true
+          node-version: "22.13"
+          cache: "pnpm"
+          cache-dependency-path: frontend/atendimento-app/pnpm-lock.yaml
+
+      - name: Instalar PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: "11.1.2"
+          run_install: false
 
       - name: Instalar dependências
         working-directory: ./frontend/atendimento-app

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -16,18 +16,18 @@ jobs:
       - name: Baixar repositório
         uses: actions/checkout@v4
 
+      - name: Instalar PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: "11.1.2"
+          run_install: false
+
       - name: Configurar Node
         uses: actions/setup-node@v4
         with:
           node-version: "22.13"
           cache: "pnpm"
           cache-dependency-path: frontend/atendimento-app/pnpm-lock.yaml
-
-      - name: Instalar PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          version: "11.1.2"
-          run_install: false
 
       - name: Instalar dependências
         working-directory: ./frontend/atendimento-app

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,6 +29,55 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: frontend/atendimento-app/pnpm-lock.yaml
 
+          name: CI Front-end
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build:
+    name: Build do projeto Front-end
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Baixar repositório
+        uses: actions/checkout@v4
+
+        - name: Aprovar builds do pnpm
+        working-directory: ./frontend/atendimento-app
+        run: pnpm approve-builds
+
+      - name: Instalar PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: "11.1.2"
+          run_install: false
+
+      - name: Configurar Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.13"
+          cache: "pnpm"
+          cache-dependency-path: frontend/atendimento-app/pnpm-lock.yaml
+
+      - name: Instalar dependências
+        working-directory: ./frontend/atendimento-app
+        run: pnpm install --frozen-lockfile
+
+      - name: Construir aplicação
+        working-directory: ./frontend/atendimento-app
+        run: pnpm run build
+
+      - name: Salvar artefato de build
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/atendimento-app/.next
+
       - name: Instalar dependências
         working-directory: ./frontend/atendimento-app
         run: pnpm install --frozen-lockfile

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoCard.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoCard.tsx
@@ -10,7 +10,6 @@ interface AtendimentoCardProps {
   numeracao: number;
   relatorio?: Relatorio[];
   atendimentos: Atendimento[];
-  onUpdated: (a: Atendimento) => void;
 }
 export default function AtendimentoCard({
   id,
@@ -19,7 +18,6 @@ export default function AtendimentoCard({
   numeracao,
   relatorio,
   atendimentos,
-  onUpdated,
 }: AtendimentoCardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -65,7 +63,6 @@ export default function AtendimentoCard({
         numeracao={numeracao}
         relatorios={relatorio}
         atendimentos={atendimentos}
-        onUpdated={onUpdated!}
       />
     </>
   );

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoDeleteModal.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoDeleteModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { X, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface AtendimentoDeleteModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    disabled: boolean;
+}
+
+export function AtendimentoDeleteModal({
+                                           isOpen,
+                                           onClose,
+                                           onConfirm,
+                                           disabled,
+                                       }: AtendimentoDeleteModalProps) {
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="flex flex-col w-full max-w-[360px] md:max-w-[650px] p-0 gap-0 rounded-[30px] overflow-hidden bg-white [&>button]:hidden">
+                <div className="p-8 flex flex-col items-center">
+                    <DialogTitle className="text-xl font-bold text-[#344054] mb-2 text-center">
+                        Tem certeza que deseja excluir?
+                    </DialogTitle>
+                    <p className="text-[#344054] text-sm mb-8 text-center">
+                        Não é possível desfazer essa ação.
+                    </p>
+
+                    <div className="flex flex-col md:flex-row gap-3 w-full">
+                        <Button
+                            variant="outline"
+                            onClick={onClose}
+                            className="w-full md:flex-1 rounded-full border-[#165BAA] text-[#165BAA] hover:bg-blue-50 h-11 cursor-pointer"
+                        >
+                            <X size={18} className="mr-2" />
+                            Cancelar
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                onConfirm();
+                                onClose();
+                            }}
+                            disabled={disabled}
+                            className="w-full md:flex-1 rounded-full bg-[#FF5C5C] hover:bg-[#ff4040] text-white h-11 cursor-pointer"
+                        >
+                            <Trash2 size={18} className="mr-2" />
+                            Apagar
+                        </Button>
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoDetailsModal.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoDetailsModal.tsx
@@ -1,9 +1,14 @@
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { X, PencilLine } from "lucide-react";
+import { X, PencilLine, Trash2 } from "lucide-react";
 import { Atendimento, Relatorio } from "../types";
-import { useState } from "react";
+import {useEffect, useState} from "react";
 import { AtendimentoModal } from "./atendimentoNovoModal";
 import AtendimentoForm from "./atendimentoForm";
+import { AtendimentoDeleteModal } from "./atendimentoDeleteModal";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deletarAtendimento } from "../services/atendimentoService";
+import { useParams } from "next/navigation";
+import { toast } from "sonner";
 
 interface AtendimentoDetailsModalProps {
   isOpen: boolean;
@@ -14,93 +19,140 @@ interface AtendimentoDetailsModalProps {
   numeracao: number;
   relatorios?: Relatorio[];
   atendimentos: Atendimento[];
-  onUpdated: (a: Atendimento) => void;
 }
 export function AtendimentoDetailsModal({
-  isOpen,
-  onClose,
-  atendimentoId,
-  data,
-  hora,
-  numeracao,
-  relatorios,
-  atendimentos,
-}: AtendimentoDetailsModalProps) {
+                                          isOpen,
+                                          onClose,
+                                          atendimentoId,
+                                          data,
+                                          hora,
+                                          numeracao,
+                                          relatorios,
+                                          atendimentos,
+                                        }: AtendimentoDetailsModalProps) {
   const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [pendingDeleteOpen, setPendingDeleteOpen] = useState(false);
+
+    useEffect(() => {
+        if (!isOpen && pendingDeleteOpen) {
+            setDeleteOpen(true);
+            setPendingDeleteOpen(false);
+        }
+    }, [isOpen, pendingDeleteOpen]);
+
+  const { id } = useParams();
+  const pacienteId = typeof id === "string" ? id : "";
+
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deletarAtendimento(pacienteId, atendimentoId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["atendimentos", pacienteId] });
+      toast.success("Atendimento apagado com sucesso.");
+      onClose();
+    },
+    onError: () => {
+      toast.error("Erro ao apagar atendimento.");
+    },
+  });
 
   const listaRelatorios =
-    relatorios && relatorios.length > 0
-      ? relatorios
-      : [{ titulo: "Sem título", descricao: "Sem descrição" }];
+      relatorios && relatorios.length > 0
+          ? relatorios
+          : [{ titulo: "Sem titulo", descricao: "Sem descricao" }];
 
   return (
-    <>
-      <Dialog open={isOpen} onOpenChange={onClose}>
-        <DialogContent className="flex flex-col w-full max-w-[360px] max-h-[569px] sm:max-w-[768px] sm:max-h-[611px] p-0 gap-0 rounded-[30px] overflow-hidden bg-white [&>button]:hidden">
-          <div className="flex items-center justify-between px-4 py-3 shrink-0">
-            <h2 className="text-xl font-bold text-[#344054]">{data}</h2>
+      <>
+        <Dialog open={isOpen} onOpenChange={onClose}>
+          <DialogContent className="flex flex-col w-full max-w-[360px] max-h-[569px] sm:max-w-[768px] sm:max-h-[611px] p-0 gap-0 rounded-[30px] overflow-hidden bg-white [&>button]:hidden">
+            <div className="flex items-center justify-between px-4 py-3 shrink-0">
+              <h2 className="text-xl font-bold text-[#344054]">{data}</h2>
 
-            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3">
               <span className="w-8 h-8 rounded-full bg-[#165BAA] text-white text-sm flex items-center justify-center font-bold">
                 {String(numeracao).padStart(2, "0")}
               </span>
 
-              <button
-                onClick={() => setEditOpen(true)}
-                className="text-[#344054] hover:cursor-pointer hover:bg-gray-100 p-1 rounded-full transition"
-              >
-                <PencilLine size={24} />
-              </button>
+                <button
+                    onClick={() => setEditOpen(true)}
+                    className="text-[#344054] hover:cursor-pointer hover:bg-gray-100 p-1 rounded-full transition"
+                >
+                  <PencilLine size={24} />
+                </button>
 
-              <button
-                onClick={onClose}
-                className="text-[#344054] hover:cursor-pointer hover:bg-gray-100 p-1 rounded-full transition"
-              >
-                <X size={24} />
-              </button>
+                <button
+                    onClick={() => {setPendingDeleteOpen(true);
+                        onClose();}}
+                    className="text-[#344054] hover:cursor-pointer hover:bg-gray-100 p-1 rounded-full transition"
+                >
+                  <Trash2 size={22} />
+                </button>
+
+                <button
+                    onClick={onClose}
+                    className="text-[#344054] hover:cursor-pointer hover:bg-gray-100 p-1 rounded-full transition"
+                >
+                  <X size={24} />
+                </button>
+              </div>
             </div>
-          </div>
 
-          <div className="h-[2px] bg-[#E8EEF7] mx-4 shrink-0"></div>
+            <div className="h-[2px] bg-[#E8EEF7] mx-4 shrink-0"></div>
 
-          <div className="overflow-y-auto custom-scrollbar px-4 pt-4">
-            <DialogTitle className="hidden">
-              Detalhes do Atendimento {data}
-            </DialogTitle>
+            <div className="overflow-y-auto custom-scrollbar px-4 pt-4">
+              <DialogTitle className="hidden">
+                Detalhes do Atendimento {data}
+              </DialogTitle>
 
-            <div className="space-y-3">
-              {listaRelatorios.map((relatorios, index) => (
-                <div key={index} className="space-y-1">
-                  <h3 className="text-base font-bold text-[#344054]">
-                    {relatorios.titulo}
-                  </h3>
-                  <p className="text-sm text-[#555555] leading-relaxed text-justify whitespace-pre-wrap">
-                    {relatorios.descricao}
-                  </p>
-                </div>
-              ))}
+              <div className="space-y-3">
+                {listaRelatorios.map((relatorios, index) => (
+                    <div key={index} className="space-y-1">
+                      <h3 className="text-base font-bold text-[#344054]">
+                        {relatorios.titulo}
+                      </h3>
+                      <p className="text-sm text-[#555555] leading-relaxed text-justify whitespace-pre-wrap">
+                        {relatorios.descricao}
+                      </p>
+                    </div>
+                ))}
 
-              <div className="h-2 w-full shrink-0" aria-hidden="true" />
+                <div className="h-2 w-full shrink-0" aria-hidden="true" />
+              </div>
             </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <AtendimentoModal open={editOpen} onOpenChange={setEditOpen} modo="edit">
-        <AtendimentoForm
-          atendimentos={atendimentos}
-          atendimentoEditavel={{
-            id: atendimentoId,
-            data,
-            hora,
-            numeracao,
-            relatorio: relatorios ?? [],
-          }}
-          onClose={() => {
-            setEditOpen(false);
-            onClose();
-          }}
+          </DialogContent>
+        </Dialog>
+
+        <AtendimentoDeleteModal
+            isOpen={deleteOpen}
+            onClose={() => setDeleteOpen(false)}
+            onConfirm={() => {
+              if (!pacienteId) {
+                toast.error("Paciente invalido.");
+                return;
+              }
+              deleteMutation.mutate();
+            }}
+            disabled={deleteMutation.isPending}
         />
-      </AtendimentoModal>
-    </>
+
+        <AtendimentoModal open={editOpen} onOpenChange={setEditOpen} modo="edit">
+          <AtendimentoForm
+              atendimentos={atendimentos}
+              atendimentoEditavel={{
+                id: atendimentoId,
+                data,
+                hora,
+                numeracao,
+                relatorio: relatorios ?? [],
+              }}
+              onClose={() => {
+                setEditOpen(false);
+                onClose();
+              }}
+          />
+        </AtendimentoModal>
+      </>
   );
 }

--- a/frontend/atendimento-app/src/features/atendimento/services/atendimentoService.ts
+++ b/frontend/atendimento-app/src/features/atendimento/services/atendimentoService.ts
@@ -24,6 +24,10 @@ export async function criarAtendimento(
   return data;
 }
 
+export async function deletarAtendimento(pacienteId: string, atendimentoId: string): Promise<void> {
+  await api.delete(`/atendimentos/${pacienteId}/${atendimentoId}`);
+}
+
 export async function editarAtendimento(
   atendimentoId: string,
   payload: AtendimentoPayload


### PR DESCRIPTION
## Contexto
A tela de Atendimento já permitia criar, listar e editar atendimentos, mas não havia fluxo para exclusão. Este PR adiciona a funcionalidade de apagar atendimentos com confirmação, sem impactar as demais funções da tela.

## O que foi feito
- **UI/UX:** Criado o modal de confirmação para exclusão de atendimentos.
- **Integração:** Integrado o endpoint `DELETE /atendimentos/{pacienteId}/{atendimentoId}` no service.
- **Componentes:** Adicionado o botão de exclusão no modal de detalhes.
- **Fluxo:** Ajustado o comportamento de abertura dos modais para evitar sobreposição na interface.
- **Gerenciamento de Estado:** Configurada a invalidação da query `["atendimentos", pacienteId]` após a exclusão para garantir a atualização automática da listagem.

## Imagens
<img width="1913" height="799" alt="image" src="https://github.com/user-attachments/assets/e06dd9b0-5931-49cc-a233-bbdabeb5dc2f" />

<img width="1898" height="830" alt="image" src="https://github.com/user-attachments/assets/da8c3f6d-8012-42de-aff5-6af9b100c3dc" />
