### PR TITLE
resolve bug of image preview in relatory and attachment

### DIFF
--- a/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
+++ b/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Upload, CirclePlus } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -58,7 +58,16 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
   const existeTexto = titulo?.trim().length > 0 && descricao?.trim().length > 0;
   const podeEnviar = existeArquivo && existeTexto;
 
-  const previewUrl = arquivo?.[0] ? URL.createObjectURL(arquivo[0]) : null;
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (arquivo && arquivo.length > 0 && arquivo[0] instanceof File) {
+      const url = URL.createObjectURL(arquivo[0]);
+      setPreviewUrl(url);
+
+      return () => URL.revokeObjectURL(url);
+    }
+    setPreviewUrl(null);
+  }, [arquivo]);
   const renderizar =
     previewUrl &&
     arquivo &&

--- a/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
+++ b/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Upload, CirclePlus, Info, FileText } from "lucide-react";
 import { pdf } from "@react-pdf/renderer";
 import { TemplateRelatorio } from "../../../components/pdf/templateRelatorio";
@@ -106,7 +106,16 @@ export default function RelatorioForm({
     setValue("arquivo", fileList, { shouldValidate: true });
   };
 
-  const previewUrl = arquivo?.[0] ? URL.createObjectURL(arquivo[0]) : null;
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (arquivo && arquivo.length > 0 && arquivo[0] instanceof File) {
+      const url = URL.createObjectURL(arquivo[0]);
+      setPreviewUrl(url);
+
+      return () => URL.revokeObjectURL(url);
+    }
+    setPreviewUrl(null);
+  }, [arquivo]);
   const renderizar =
     previewUrl &&
     arquivo &&


### PR DESCRIPTION
Atualmente, a aplicação não mostrava a prévia do arquivo.

O problema de a imagem não aparecer antes era porque a gente tava usando o URL.createObjectURL direto no corpo do componente. No React isso dá ruim: toda vez que a tela atualizava (re-render), ele tentava gerar uma URL nova. Além de bagunçar o estado e fazer a imagem sumir, isso gera vazamento de memória (memory leak).

A solução foi jogar essa geração de URL pra dentro de um useEffect. Assim, a URL da prévia só é gerada quando a gente realmente seleciona um arquivo e é limpa direitinho da memória quando o componente desmonta.

- Implementa exibição de imagem baseada em URL.createObjectURL.
- Corrige bug onde a imagem não era renderiza.
- Gerencia estado da URL de prévia com useEffect para prevenir vazamentos de memória.
- Resolve issue #281.