### PR TITLE
fix: preview de PDFs e correção de download automático

### DIFF
--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/config/S3Config.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.net.URI;
@@ -15,47 +16,52 @@ import java.net.URI;
 @Configuration
 @Profile("prod")
 public class S3Config {
-    @Value("${s3.endpoint}")
-    private String s3Endpoint;
+        @Value("${s3.endpoint}")
+        private String s3Endpoint;
 
-    @Value("${s3.region}")
-    private String s3Region;
+        @Value("${s3.external-endpoint}")
+        private String s3ExternalEndpoint;
 
-    @Value("${s3.access-key}")
-    private String s3AccessKey;
+        @Value("${s3.region}")
+        private String s3Region;
 
-    @Value("${s3.secret-key}")
-    private String s3SecretKey;
+        @Value("${s3.access-key}")
+        private String s3AccessKey;
 
-    @Bean
-    public S3Client s3Client() {
-        return S3Client.builder()
-                .endpointOverride(URI.create(s3Endpoint))
-                .region(Region.of(s3Region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(
-                                        s3AccessKey,
-                                        s3SecretKey
-                                )
-                        )
-                )
-                .build();
-    }
+        @Value("${s3.secret-key}")
+        private String s3SecretKey;
 
-    @Bean
-    public S3Presigner s3Presigner() {
-        return S3Presigner.builder()
-                .endpointOverride(URI.create(s3Endpoint))
-                .region(Region.of(s3Region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(
-                                        s3AccessKey,
-                                        s3SecretKey
-                                )
-                        )
-                )
-                .build();
-    }
+        @Bean
+        public S3Client s3Client() {
+                return S3Client.builder()
+                                .endpointOverride(URI.create(s3Endpoint))
+                                .region(Region.of(s3Region))
+                                .forcePathStyle(true)
+                                .credentialsProvider(
+                                                StaticCredentialsProvider.create(
+                                                                AwsBasicCredentials.create(
+                                                                                s3AccessKey,
+                                                                                s3SecretKey)))
+                                .build();
+        }
+
+        @Bean
+        public S3Presigner s3Presigner() {
+                S3Configuration s3Configuration = S3Configuration.builder()
+                                .pathStyleAccessEnabled(true)
+                                .build();
+
+                // Usa o endpoint externo (acessível pelo navegador) para que as URLs
+                // pre-assinadas funcionem diretamente no browser sem reescrita de host.
+                return S3Presigner.builder()
+                                .endpointOverride(URI.create(s3ExternalEndpoint))
+                                .region(Region.of(s3Region))
+                                .serviceConfiguration(s3Configuration)
+                                .credentialsProvider(
+                                                StaticCredentialsProvider.create(
+                                                                AwsBasicCredentials.create(
+                                                                                s3AccessKey,
+                                                                                s3SecretKey)))
+                                .build();
+        }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/minio/MinioPresignedUrlService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/minio/MinioPresignedUrlService.java
@@ -25,21 +25,23 @@ public class MinioPresignedUrlService implements PresignedUrlService {
 
     @Cacheable(
             value = "presignedUrls",
-            key = "'presigned:' + ':' + #objectName",  // ← CHAVE EXPLÍCITA
+            key = "'presigned:' + ':' + #objectName", 
             unless = "#result == null"
     )
     public String gerarUrlPreAssinada(String objectName) {
         try {
+            java.util.Map<String, String> extraParams = new java.util.HashMap<>();
+            extraParams.put("response-content-disposition", "inline; filename=\"" + objectName + "\"");
+            
+            if (objectName.toLowerCase().endsWith(".pdf")) {
+                extraParams.put("response-content-type", "application/pdf");
+            }
+
             String url = client.getPresignedObjectUrl(
                     GetPresignedObjectUrlArgs.builder()
                             .bucket(BUCKET_NAME)
                             .object(objectName)
-                            .extraQueryParams(
-            Map.of(
-                "response-content-disposition",
-                "attachment; filename=" + objectName
-            )
-        )
+                            .extraQueryParams(extraParams) 
                             .method(io.minio.http.Method.GET)
                             .expiry(60 * 60)
                             .build()

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/s3/S3PresignedUrlService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/s3/S3PresignedUrlService.java
@@ -19,24 +19,28 @@ public class S3PresignedUrlService implements PresignedUrlService {
     private final S3Presigner s3Presigner;
     @Value("${bucket.name}")
     private String BUCKET_NAME;
+    
     public S3PresignedUrlService(S3Presigner s3Presigner) {
         this.s3Presigner = s3Presigner;
     }
 
     @Cacheable(
             value = "presignedUrls",
-            key = "'presigned:' + ':' + #objectName",  // ← CHAVE EXPLÍCITA
+            key = "'presigned:' + ':' + #objectName", 
             unless = "#result == null"
     )
     public String gerarUrlPreAssinada(String objectName) {
         try {
-            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+            GetObjectRequest.Builder requestBuilder = GetObjectRequest.builder()
                     .bucket(BUCKET_NAME)
                     .key(objectName)
-                    .responseContentDisposition(
-        "attachment; filename=\"" + objectName + "\""
-    )
-                    .build();
+                    .responseContentDisposition("inline; filename=\"" + objectName + "\"");
+
+            if (objectName.toLowerCase().endsWith(".pdf")) {
+                requestBuilder.responseContentType("application/pdf");
+            }
+
+            GetObjectRequest getObjectRequest = requestBuilder.build();
 
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                     .getObjectRequest(getObjectRequest)

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/s3/S3Service.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/storage/s3/S3Service.java
@@ -48,7 +48,7 @@ public class S3Service implements ObjectStorageService {
     }
 
     private void colocarArquivo(String objectName, MultipartFile file) {
-        try (InputStream is = file.getInputStream()) {
+        try {
             String contentType = file.getContentType();
             if (contentType == null) {
                 contentType = "application/octet-stream";
@@ -61,14 +61,17 @@ public class S3Service implements ObjectStorageService {
                     .contentLength(file.getSize())
                     .build();
 
-            client.putObject(request, RequestBody.fromInputStream(is, file.getSize()));
+            // MUDANÇA AQUI: Removido o try-with-resources do InputStream e usado fromBytes
+            client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 
         } catch (Exception e) {
+            e.printStackTrace(); // <--- IMPORTANTE: Deixe isso aqui para ver o erro no terminal do docker caso
+                                 // algo falhe
             throw new CloudStorageException("Erro ao enviar arquivo para o armazenamento em nuvem.", e);
         }
     }
 
-    public void deletarArquivo(String objectName){
+    public void deletarArquivo(String objectName) {
         try {
             DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                     .bucket(BUCKET_NAME)
@@ -77,7 +80,7 @@ public class S3Service implements ObjectStorageService {
 
             client.deleteObject(deleteRequest);
 
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             throw new CloudStorageException("Erro de comunicação ao tentar apagar o arquivo na nuvem.", e);
         }

--- a/backend/atendimento/src/main/resources/application-prod.properties
+++ b/backend/atendimento/src/main/resources/application-prod.properties
@@ -9,6 +9,7 @@ spring.datasource.password=${DB_PASSWORD}
 
 # B2 - S3
 s3.endpoint=${S3_ENDPOINT}
+s3.external-endpoint=${S3_EXTERNAL_ENDPOINT}
 s3.region=${S3_REGION}
 s3.access-key=${S3_ACCESS_KEY}
 s3.secret-key=${S3_SECRET_KEY}

--- a/backend/atendimento/src/main/resources/local-secrets.properties
+++ b/backend/atendimento/src/main/resources/local-secrets.properties
@@ -1,4 +1,0 @@
-jwt.secret=+zoNa56O6cA4iisnky5nmqaBbK9lMrfNxtenX+75cQZf7tvUNI4SuK5ZJiF4cOYKS+xgLDMnet8ze2F6/tSQBQ==
-jwt.expiration.minutes=30
-jwt.cookie.secure=false
-auth.mock.enabled=false

--- a/backend/atendimento/src/main/resources/local-secrets.properties
+++ b/backend/atendimento/src/main/resources/local-secrets.properties
@@ -1,0 +1,4 @@
+jwt.secret=+zoNa56O6cA4iisnky5nmqaBbK9lMrfNxtenX+75cQZf7tvUNI4SuK5ZJiF4cOYKS+xgLDMnet8ze2F6/tSQBQ==
+jwt.expiration.minutes=30
+jwt.cookie.secure=false
+auth.mock.enabled=false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,6 +44,7 @@ services:
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       S3_ENDPOINT: http://minio:9000
+      S3_EXTERNAL_ENDPOINT: http://localhost:9000
       S3_REGION: us-east-1
       S3_ACCESS_KEY: ${MINIO_ROOT_USER}
       S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD}

--- a/frontend/atendimento-app/src/components/pdf/PdfViewerInner.tsx
+++ b/frontend/atendimento-app/src/components/pdf/PdfViewerInner.tsx
@@ -1,12 +1,9 @@
-// components/PDFThumbnailSimple.tsx
 'use client';
 
-import { useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
-import 'react-pdf/dist/esm/Page/TextLayer.css';
 
-// Configuração do worker - Método mais confiável
+
+
 pdfjs.GlobalWorkerOptions.workerSrc = 
   `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
@@ -19,34 +16,22 @@ export default function PDFThumbnailSimple({
   pdfUrl, 
   width = 300 
 }: PDFThumbnailProps) {
-  const [numPages, setNumPages] = useState<number | null>(null);
-  const [pageNumber] = useState<number>(1);
-
-  function onDocumentLoadSuccess({ numPages }: { numPages: number }) {
-    setNumPages(numPages);
-  }
-
   return (
-    <div style={{ width: `${width}px` }}>
+    <div className="w-full h-full flex items-center justify-center overflow-hidden">
       <Document
         file={pdfUrl}
-        onLoadSuccess={onDocumentLoadSuccess}
-        loading={<div>Carregando PDF...</div>}
-        error={<div>Erro ao carregar PDF</div>}
+        loading={<div className="text-xs text-gray-400">Gerando thumbnail...</div>}
+        error={<div className="text-xs text-red-400">Sem preview</div>}
+        className="flex items-center justify-center"
       >                                                             
         <Page 
-          pageNumber={pageNumber} 
+          pageNumber={1} 
           width={width}                                                             
           renderTextLayer={false}
           renderAnnotationLayer={false}
+          className="pointer-events-none shadow-sm" 
         />
       </Document>
-      
-      {numPages && (
-        <p style={{ fontSize: '0.875rem', color: '#666', marginTop: '8px' }}>
-          Página {pageNumber} de {numPages}
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/atendimento-app/src/features/anexo/components/anexoCard.tsx
+++ b/frontend/atendimento-app/src/features/anexo/components/anexoCard.tsx
@@ -23,6 +23,7 @@ export default function AnexoCard({
   const renderizar = renderizarFormatoArquivo(
     fileName.split(".").pop() || "",
     imageUrl || "",
+    'thumbnail',
   );
   return (
     <div className="w-full bg-white rounded-3xl shadow-md p-4 border border-gray-100 flex flex-col h-[320px] transition-all">

--- a/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
+++ b/frontend/atendimento-app/src/features/anexo/components/anexoForm.tsx
@@ -71,7 +71,7 @@ export default function AnexoForm({ onSubmit }: AnexoFormProps) {
   const renderizar =
     previewUrl &&
     arquivo &&
-    renderizarFormatoArquivo(arquivo[0].type, previewUrl);
+    renderizarFormatoArquivo(arquivo[0].type, previewUrl, 'form');
 
   const removerArquivo = () => setValue("arquivo", undefined);
 

--- a/frontend/atendimento-app/src/features/anexo/components/anexoModal.tsx
+++ b/frontend/atendimento-app/src/features/anexo/components/anexoModal.tsx
@@ -76,6 +76,7 @@ export function AnexoViewModal({
   const renderizar = renderizarFormatoArquivo(
     data.nomeArquivo.split(".").pop() || "",
     data.presignedUrl || "",
+    'full',
   );
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4 py-6 animate-in fade-in duration-200">
@@ -96,7 +97,7 @@ export function AnexoViewModal({
           {data.descricao}
         </p>
 
-        <div className="bg-gray-50 flex items-center justify-center w-full h-[400px] px-4">
+        <div className="bg-gray-50 flex items-center justify-center w-full min-h-[500px] px-4">
           {data.presignedUrl ? (
             renderizar
           ) : (

--- a/frontend/atendimento-app/src/features/relatorio/components/relatorioCard.tsx
+++ b/frontend/atendimento-app/src/features/relatorio/components/relatorioCard.tsx
@@ -20,10 +20,14 @@ export default function RelatorioCard({
   onView,
   onDelete,
 }: RelatorioCardProps) {
+  const extensao = (fileName.split(".").pop() || "").toLowerCase();
+  
   const renderizar = renderizarFormatoArquivo(
-    fileName.split(".").pop() || "",
+    extensao,
     imageUrl || "",
+    'thumbnail',
   );
+
   return (
     <div className="w-full bg-white rounded-3xl shadow-md p-4 border border-gray-100 flex flex-col h-[320px] transition-all">
       <div className="flex items-center justify-between mb-3">

--- a/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
+++ b/frontend/atendimento-app/src/features/relatorio/components/relatorioForm.tsx
@@ -107,7 +107,7 @@ export default function RelatorioForm({
   const renderizar =
     previewUrl &&
     arquivo &&
-    renderizarFormatoArquivo(arquivo[0].type, previewUrl);
+    renderizarFormatoArquivo(arquivo[0].type, previewUrl, 'form');
 
   const removerArquivo = () =>
     setValue("arquivo", [] as unknown as FileList, { shouldValidate: true });

--- a/frontend/atendimento-app/src/features/relatorio/components/relatorioModal.tsx
+++ b/frontend/atendimento-app/src/features/relatorio/components/relatorioModal.tsx
@@ -76,6 +76,7 @@ export function RelatorioViewModal({
   const renderizar = renderizarFormatoArquivo(
     data.nomeArquivo.split(".").pop() || "",
     data.presignedUrl || "",
+    'full',
   );
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4 py-6 animate-in fade-in duration-200">
@@ -96,7 +97,7 @@ export function RelatorioViewModal({
           {data.descricao}
         </p>
 
-        <div className=" bg-white rounded-[24px] w-full max-w-[632px] max-h-[90vh] flex flex-col shadow-2xl slide-in-from-bottom-10 overflow-y-auto">
+        <div className="bg-gray-50 flex items-center justify-center w-full min-h-[500px] px-4">
           {data.presignedUrl ? (
             renderizar
           ) : (

--- a/frontend/atendimento-app/src/utils/renderizarFormatoArquivo.tsx
+++ b/frontend/atendimento-app/src/utils/renderizarFormatoArquivo.tsx
@@ -1,40 +1,73 @@
-import PdfPreview from "@/components/pdf/PdfViewner";
 import Image from "next/image";
 import { JSX } from "react";
+import { FileText } from "lucide-react";
 
 type TipoNormalizado = 'pdf' | 'image';
 
 const TIPOS_PDF = ['application/pdf', 'pdf'];
-const TIPOS_IMAGEM = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic', 'image/heif', 'jpeg', 'jpg', 'heic', 'heif'];
+const TIPOS_IMAGEM = ['image/jpeg', 'image/jpg', 'image/png', 'image/heic', 'image/heif', 'jpeg', 'jpg', 'png', 'heic', 'heif'];
+
+function tratarUrl(url: string): string {
+  return url.replace("://minio:9000", "://localhost:9000");
+}
+
+function normalizarTipo(tipo: string): TipoNormalizado | null {
+  const tipoTratado = tipo.toLowerCase().trim();
+  if (TIPOS_PDF.includes(tipoTratado)) return 'pdf';
+  if (TIPOS_IMAGEM.includes(tipoTratado)) return 'image';
+  return null;
+}
 
 export function renderizarFormatoArquivo(
   tipo: string,
-  url: string
+  url: string,
+  modo: 'thumbnail' | 'full' | 'form' = 'full'
 ): JSX.Element | null {
-
-  let tipoNormalizado: TipoNormalizado | null = null;
-
-  if (TIPOS_PDF.includes(tipo)) {
-    tipoNormalizado = 'pdf';
-  } else if (TIPOS_IMAGEM.includes(tipo)) {
-    tipoNormalizado = 'image';
-  }
-
+  const tipoNormalizado = normalizarTipo(tipo);
   if (!tipoNormalizado) return null;
 
-  const opcoesFormatoArquivo: Record<TipoNormalizado, () => JSX.Element> = {
-    pdf: () => <PdfPreview pdfUrl={url} />,
-    image: () => (
-      <Image
-        src={url}
-        alt="Pré-visualização"
-        width={400}
-        height={400}
-        className="w-full h-full object-contain"
-        unoptimized
-      />
-    ),
-  };
+  const urlTratada = tratarUrl(url);
 
-  return opcoesFormatoArquivo[tipoNormalizado]();
+  if (tipoNormalizado === 'pdf') {
+    return renderizarPdf(urlTratada, modo);
+  }
+
+  return renderizarImagem(urlTratada, modo);
+}
+
+function renderizarPdf(url: string, modo: 'thumbnail' | 'full' | 'form'): JSX.Element {
+  if (modo === 'thumbnail') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 w-full h-full text-[#0D4F97]">
+        <FileText size={48} strokeWidth={1.5} />
+        <span className="text-xs font-medium text-gray-500">Documento PDF</span>
+      </div>
+    );
+  }
+
+  const alturaClasse = modo === 'form' ? 'h-full min-h-[200px]' : 'min-h-[500px]';
+
+  return (
+    <iframe
+      src={`${url}#toolbar=1&navpanes=0`}
+      title="Pré-visualização PDF"
+      className={`w-full ${alturaClasse} border-0`}
+      style={{ backgroundColor: '#f5f5f5' }}
+    />
+  );
+}
+
+function renderizarImagem(url: string, modo: 'thumbnail' | 'full' | 'form'): JSX.Element {
+  const tamanho = modo === 'thumbnail' ? 200 : 500;
+
+  return (
+    <Image
+      src={url}
+      alt="Pré-visualização"
+      width={tamanho}
+      height={tamanho}
+      className="w-full h-full object-contain"
+      unoptimized
+    />
+  );
 }

--- a/frontend/atendimento-app/src/utils/renderizarFormatoArquivo.tsx
+++ b/frontend/atendimento-app/src/utils/renderizarFormatoArquivo.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { JSX } from "react";
 import { FileText } from "lucide-react";
+import PdfPreview from "@/components/pdf/PdfViewner";
 
 type TipoNormalizado = 'pdf' | 'image';
 
@@ -38,22 +39,23 @@ export function renderizarFormatoArquivo(
 function renderizarPdf(url: string, modo: 'thumbnail' | 'full' | 'form'): JSX.Element {
   if (modo === 'thumbnail') {
     return (
-      <div className="flex flex-col items-center justify-center gap-2 w-full h-full text-[#0D4F97]">
-        <FileText size={48} strokeWidth={1.5} />
-        <span className="text-xs font-medium text-gray-500">Documento PDF</span>
+      <div className="flex flex-col items-center justify-center w-full h-full pointer-events-none overflow-hidden bg-[#f8fafd]">
+        <PdfPreview pdfUrl={url} width={300} />
       </div>
     );
   }
 
-  const alturaClasse = modo === 'form' ? 'h-full min-h-[200px]' : 'min-h-[500px]';
+
+  const limitesAltura = modo === 'form' ? 'max-h-[300px]' : 'max-h-[60vh]';
 
   return (
-    <iframe
-      src={`${url}#toolbar=1&navpanes=0`}
-      title="Pré-visualização PDF"
-      className={`w-full ${alturaClasse} border-0`}
-      style={{ backgroundColor: '#f5f5f5' }}
-    />
+    <div className={`flex flex-col items-center justify-center w-full h-full ${limitesAltura} overflow-hidden p-4`}>
+
+      <div className="w-full h-full flex items-center justify-center [&_canvas]:max-w-full [&_canvas]:max-h-full [&_canvas]:!w-auto [&_canvas]:!h-auto [&_canvas]:object-contain [&_canvas]:shadow-md [&_canvas]:rounded-lg">
+
+        <PdfPreview pdfUrl={url} width={800} />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
O que foi resolvido:

- Acabou o bug do PDF baixando sozinho ao abrir a tela ou criar um relatório.

- O preview nos cards e modais agora funciona 100% como uma imagem estática, sem injetar o leitor nativo do navegador (que tava quebrando o layout no Firefox).

O que mudou:

- Backend: Ajustadas as configs do S3 e MinIO para gerar a URL pré-assinada com inline e forçar o Content-Type de application/pdf.

- Frontend: Remoção do iframe e implementação do react-pdf (PdfPreview) para gerar a miniatura da página 1 em canvas.

- Estilização: Ajuste no CSS (object-contain via Tailwind) para garantir que a foto do PDF respeite os limites do modal sem vazar.