### PR TITLE
refactor: refatora entidades para views somente leitura do atendimento (#306)

### DIFF
--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ProfissionalSaudeController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ProfissionalSaudeController.java
@@ -35,12 +35,6 @@ public class ProfissionalSaudeController {
         return ResponseEntity.ok().body(pacientes);
     }
 
-    @GetMapping("/primeiro-nome")
-    public ResponseEntity<String> obterPrimeiroNome(@AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado) {
-        String nome = profissionalSaudeService.getPrimeiroNome(usuarioAutenticado.getId());
-        return ResponseEntity.ok().body(nome);
-    }
-
     @GetMapping("/pacientes-option")
     public ResponseEntity<List<PacienteOptionDTO>> pacientesOption(
             @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado) {

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
@@ -10,6 +10,6 @@ public record AgendamentoResponseDTO(
         String nomePaciente,
         LocalDate data,
         LocalTime time,
-        Long numeroAtendimento,
+        String numeroAtendimento,
         boolean status) {
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AtendimentoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AtendimentoResponseDTO.java
@@ -10,6 +10,6 @@ public record AtendimentoResponseDTO(
     List<TopicoResponseDTO> relatorio,
     LocalDate data,
     LocalTime hora,
-    Long numeracao,
+    String numeracao,
     boolean status) {
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/PacienteResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/PacienteResponseDTO.java
@@ -1,4 +1,5 @@
 package br.org.apae.atendimento.dtos.response;
+
 import java.util.Set;
 import java.util.UUID;
 import java.time.LocalDate;

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/ProfissionalResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/ProfissionalResponseDTO.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 public record ProfissionalResponseDTO(
         UUID id,
-        String primeiroNome,
         String nomeCompleto,
         String email,
         String contato

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Agendamento.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Agendamento.java
@@ -1,12 +1,20 @@
 package br.org.apae.atendimento.entities;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "agendamento")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "agendamento", schema = "atendimento")
 public class Agendamento {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -19,7 +27,7 @@ public class Agendamento {
     private LocalDateTime dataHora;
 
     @Column(name = "numeracao")
-    private Long numeracao;
+    private String numeracao;
 
     @ManyToOne
     @JoinColumn(name = "profissional_id")
@@ -28,62 +36,4 @@ public class Agendamento {
     @ManyToOne
     @JoinColumn(name = "paciente_id")
     private Paciente paciente;
-
-    public Agendamento() {
-    }
-
-    public Agendamento(UUID id, ProfissionalSaude profissionalSaude, Paciente paciente, boolean status) {
-        this.id = id;
-        this.profissional = profissionalSaude;
-        this.paciente = paciente;
-        this.status = status;
-    }
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public boolean isStatus() {
-        return status;
-    }
-
-    public void setStatus(boolean status) {
-        this.status = status;
-    }
-
-    public LocalDateTime getDataHora() {
-        return dataHora;
-    }
-
-    public void setDataHora(LocalDateTime dataHora) {
-        this.dataHora = dataHora;
-    }
-
-    public ProfissionalSaude getProfissional() {
-        return profissional;
-    }
-
-    public void setProfissional(ProfissionalSaude profissional) {
-        this.profissional = profissional;
-    }
-
-    public Paciente getPaciente() {
-        return paciente;
-    }
-
-    public void setPaciente(Paciente paciente) {
-        this.paciente = paciente;
-    }
-
-    public Long getNumeracao() {
-        return numeracao;
-    }
-
-    public void setNumeracao(Long numeracao) {
-        this.numeracao = numeracao;
-    }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 
 
 @Entity
-@Table(name = "anexo")
+@Table(name = "anexo", schema = "atendimento")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 @Entity
-@Table(name = "atendimento")
+@Table(name = "atendimento", schema = "atendimento")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -27,7 +27,7 @@ public class Atendimento {
     private LocalDateTime dataAtendimento;
 
     @Column(name = "numeracao")
-    private Long numeracao;
+    private String numeracao;
 
     @ManyToOne
     @JoinColumn(name = "paciente_id")

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Paciente.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Paciente.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -14,15 +13,15 @@ import java.time.LocalDate;
 import java.util.*;
 
 @Entity
-@Immutable // SOMENTE LEITURA (View)
-@Table(name = "vw_pacientes")
+@Immutable
+@Table(name = "vw_pacientes", schema = "atendimento")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Paciente {
 
     @Id
-    @Column(name = "id")
+    @Column(name = "paciente_id")
     private UUID id;
 
     @Column(name = "nome")
@@ -37,10 +36,6 @@ public class Paciente {
     @Column(name = "contato")
     private String contato;
 
-    @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "responsaveis")
-    private Set<String> responsaveis = new HashSet<>();
-
     @Column(name = "cidade")
     private String cidade;
 
@@ -53,21 +48,16 @@ public class Paciente {
     @Column(name = "numero_casa")
     private Integer numeroCasa;
 
-    @Transient
-    private String fotoPreAssinada;
-
-    @Column(name = "ativo")
-    private Boolean ativo = true;
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "responsaveis")
+    private Set<String> responsaveis = new HashSet<>();
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "transtornos")
     private Set<String> transtornos = new HashSet<>();
 
-    @OneToMany(mappedBy = "paciente")
-    private Set<Atendimento> atendimentos = new HashSet<>();
-
+    @Transient
     @JsonIgnore
-    @ManyToMany(mappedBy = "pacientes")
-    private Set<ProfissionalSaude> profissionais = new HashSet<>();
+    private String fotoPreAssinada;
 
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/ProfissionalSaude.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/ProfissionalSaude.java
@@ -5,23 +5,23 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.hibernate.annotations.Immutable; // IMPORTANTE
+import org.hibernate.annotations.Immutable;
 
 import java.util.*;
 
 @Entity
-@Immutable // Somente Leitura
-@Table(name = "vw_profissionais") // Aponta para a view exigida pelo PO
+@Immutable
+@Table(name = "vw_profissional_saude", schema = "atendimento")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProfissionalSaude {
 
     @Id
+    @Column(name = "profissional_saude_id")
     private UUID id;
 
-    @Column(name = "nome") // Mapeado para a View
+    @Column(name = "nome")
     private String nomeCompleto;
 
     @Column(name = "registro_profissional")
@@ -40,32 +40,10 @@ public class ProfissionalSaude {
     @Column(name = "perfil")
     private String perfil;
 
-    @Column(name = "status")
-    private String status;
+    @Column(name = "ativo")
+    private Boolean ativo;
 
-    // --- CAMPOS IGNORADOS PELO BANCO DE DADOS (@Transient) ---
-    @Transient
-    private String primeiroNome;
-
-    @Transient
+    @Column(name = "contato")
     private String contato;
-    // ---------------------------------------------------------
-
-    @JsonIgnore
-    @ManyToMany()
-    @JoinTable(
-            name = "profissional_paciente",
-            joinColumns = @JoinColumn(name = "profissional_id"),
-            inverseJoinColumns = @JoinColumn(name = "paciente_id")
-    )
-    private Set<Paciente> pacientes = new HashSet<>();
-
-    @JsonIgnore
-    @OneToMany(mappedBy = "profissional")
-    private Set<Atendimento> atendimentos = new HashSet<>();
-
-    @JsonIgnore
-    @OneToMany(mappedBy = "profissional")
-    private Set<Arquivo> arquivos = new HashSet<>();
 
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/TipoArquivo.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/TipoArquivo.java
@@ -1,35 +1,27 @@
 package br.org.apae.atendimento.entities;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Entity(name = "tipo_arquivo")
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tipo_arquivo", schema = "atendimento")
 public class TipoArquivo {
+
     @Id
+    @Column(name = "id")
     private Long id;
+
+    @Column(name = "tipo")
     private String tipo;
 
-    public TipoArquivo() {
-    }
-
-    public TipoArquivo(Long id, String tipo) {
-        this.id = id;
-        this.tipo = tipo;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getTipo() {
-        return tipo;
-    }
-
-    public void setTipo(String tipo) {
-        this.tipo = tipo;
-    }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Topico.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Topico.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 import java.util.UUID;
 
 @Entity
-@Table(name = "topico")
+@Table(name = "topico", schema = "atendimento")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
@@ -25,6 +25,7 @@ public class AgendamentoMapper extends AbstractMapper<Agendamento, AgendamentoRe
 
     @Override
     public AgendamentoResponseDTO toDTOPadrao(Agendamento entidadePadrao) {
+
         return new AgendamentoResponseDTO(
                 entidadePadrao.getId(),
                 entidadePadrao.getPaciente().getId(),

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/PacienteMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/PacienteMapper.java
@@ -17,17 +17,13 @@ public class PacienteMapper extends AbstractMapper<Paciente, Void, PacienteRespo
 
     @Override
     public PacienteResponseDTO toDTOPadrao(Paciente paciente) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(paciente.getCidade())
-                .append(", ")
-                .append(paciente.getRua())
-                .append(", ")
-                .append(paciente.getBairro())
-                .append(", ")
-                .append(paciente.getNumeroCasa())
-                .append(".");
-
-        String endereco = sb.toString();
+        String endereco = String.format(
+                "%s, %s, %s, %s.",
+                paciente.getCidade(),
+                paciente.getRua(),
+                paciente.getBairro(),
+                paciente.getNumeroCasa()
+        );
 
         return new PacienteResponseDTO(
                 paciente.getId(),

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ProfissionalMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ProfissionalMapper.java
@@ -17,11 +17,9 @@ public class ProfissionalMapper extends AbstractMapper<ProfissionalSaude, Void, 
     public ProfissionalResponseDTO toDTOPadrao(ProfissionalSaude profissional) {
         return new ProfissionalResponseDTO(
                 profissional.getId(),
-                profissional.getPrimeiroNome(),
                 profissional.getNomeCompleto(),
                 profissional.getEmail(),
                 profissional.getContato()
         );
     }
-
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
@@ -17,13 +17,14 @@ import java.util.UUID;
 public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> {
     List<Atendimento> findByPacienteIdAndProfissionalIdOrderByDataAtendimento(UUID pacienteId, UUID profissionalId);
 
-    @Query("""
-        SELECT MAX(a.numeracao)
-        FROM Atendimento a
-        WHERE MONTH(a.dataAtendimento) = :mes
-          AND YEAR(a.dataAtendimento) = :ano
-          AND a.profissional.id = :profissionalId
-    """)
+    @Query(value = """
+        SELECT MAX(CAST(numeracao AS BIGINT))
+        FROM atendimento.atendimento
+        WHERE EXTRACT(MONTH FROM data_atendimento) = :mes
+          AND EXTRACT(YEAR FROM data_atendimento) = :ano
+          AND profissional_id = :profissionalId
+          AND numeracao ~ '^[0-9]+$'
+    """, nativeQuery = true)
     Long findMaxNumeracaoByMesAndAno(@Param("mes") int mes, @Param("ano") int ano, @Param("profissionalId") UUID profissionalId);
 
     @Query("""

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/PacienteRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/PacienteRepository.java
@@ -15,14 +15,12 @@ import br.org.apae.atendimento.entities.Paciente;
 
 @Repository
 public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
-    @Query("""
-    SELECT COUNT(p) > 0 
-    FROM Paciente p 
-    JOIN p.profissionais prof
-    WHERE p.id = :pacienteId
-      AND prof.id = :profissionalId
-    """)
-    boolean existeRelacao(UUID pacienteId, UUID profissionalId);
+
+    @Query(value = "SELECT CASE WHEN COUNT(1) > 0 THEN true ELSE false END " +
+            "FROM atendimento.profissional_paciente pp " +
+            "WHERE pp.paciente_id = :pacienteId AND pp.profissional_id = :profissionalId",
+            nativeQuery = true)
+    boolean existeRelacao(@Param("pacienteId") UUID pacienteId, @Param("profissionalId") UUID profissionalId);
 
     @Query("""
         SELECT p.nomeCompleto
@@ -31,17 +29,29 @@ public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
         """)
     String findNomeCompletoById(@Param("pacienteId") UUID pacienteId);
 
+    @Query(value = "SELECT vp.* FROM atendimento.vw_pacientes vp " +
+            "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
+            "WHERE pp.profissional_id = :profissionalId",
+            nativeQuery = true)
+    List<Paciente> findByProfissionalId(@Param("profissionalId") UUID profissionalId);
 
-    List<Paciente>findByProfissionais_Id(UUID profissionalId);
-    @Query("""
-        SELECT DISTINCT p
-        FROM Paciente p
-        JOIN p.profissionais prof
-        WHERE prof.id = :profissionalId
-          AND (CAST(:nome AS String) IS NULL OR LOWER(p.nomeCompleto) LIKE LOWER(CONCAT('%', CAST(:nome AS String), '%')))
-          AND (CAST(:cpf AS String) IS NULL OR p.cpf LIKE CONCAT('%', CAST(:cpf AS String), '%'))
-          AND (CAST(:cidade AS String) IS NULL OR LOWER(p.cidade) LIKE LOWER(CONCAT('%', CAST(:cidade AS String), '%')))
-    """)
+    @Query(value = "" +
+            "SELECT DISTINCT vp.* " +
+            "FROM atendimento.vw_pacientes vp " +
+            "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
+            "WHERE pp.profissional_id = :profissionalId " +
+            "  AND (:nome IS NULL OR LOWER(vp.nome) LIKE CONCAT('%', LOWER(:nome), '%')) " +
+            "  AND (:cpf IS NULL OR vp.cpf LIKE CONCAT('%', :cpf, '%')) " +
+            "  AND (:cidade IS NULL OR LOWER(vp.cidade) LIKE CONCAT('%', LOWER(:cidade), '%'))",
+            countQuery = "" +
+                    "SELECT COUNT(DISTINCT vp.paciente_id) " +
+                    "FROM atendimento.vw_pacientes vp " +
+                    "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
+                    "WHERE pp.profissional_id = :profissionalId " +
+                    "  AND (:nome IS NULL OR LOWER(vp.nome) LIKE CONCAT('%', LOWER(:nome), '%')) " +
+                    "  AND (:cpf IS NULL OR vp.cpf LIKE CONCAT('%', :cpf, '%')) " +
+                    "  AND (:cidade IS NULL OR LOWER(vp.cidade) LIKE CONCAT('%', LOWER(:cidade), '%'))",
+            nativeQuery = true)
     Page<Paciente> buscarPaciente(
             @Param("profissionalId") UUID profissionalId,
             @Param("nome") String nome,
@@ -51,6 +61,6 @@ public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
     );
 
     @Query("SELECT new br.org.apae.atendimento.dtos.response.PacienteDropdownResponseDTO(p.id, p.nomeCompleto) " +
-    "FROM Paciente p WHERE p.ativo = true ORDER BY p.nomeCompleto ASC")
+    "FROM Paciente p ORDER BY p.nomeCompleto ASC")
     List<PacienteDropdownResponseDTO> listarParaDropdown();
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/ProfissionalSaudeRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/ProfissionalSaudeRepository.java
@@ -21,6 +21,6 @@ public interface ProfissionalSaudeRepository extends JpaRepository<ProfissionalS
     Optional<ProfissionalSaude> findByEmailIgnoreCase(String email);
 
     @Query("SELECT new br.org.apae.atendimento.dtos.response.ProfissionalDropdownResponseDTO(p.id, p.nomeCompleto) " +
-    "FROM ProfissionalSaude p WHERE p.status = 'ATIVO' ORDER BY p.nomeCompleto ASC")
+    "FROM ProfissionalSaude p WHERE p.ativo = true ORDER BY p.nomeCompleto ASC")
     List<ProfissionalDropdownResponseDTO> listarParaDropdown();
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
@@ -135,9 +135,9 @@ public class AgendamentoService {
         agendamento.setStatus(true);
 
         if (existAtendimento) {
-            agendamento.setNumeracao(numeracaoAtual);
+            agendamento.setNumeracao(String.valueOf(numeracaoAtual));
         } else {
-            agendamento.setNumeracao(numeracaoAtual + 1);
+            agendamento.setNumeracao(String.valueOf(numeracaoAtual + 1));
         }
     }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
@@ -89,7 +89,7 @@ public class AtendimentoService {
         }
     }
 
-    public void tratarAgendamento(UUID pacienteId, LocalDate data, Long numeracao) {
+    public void tratarAgendamento(UUID pacienteId, LocalDate data, String numeracao) {
         Agendamento agendamento = agendamentoService.buscarAgendamentoPorDataEPaciente(data, pacienteId);
         agendamento.setNumeracao(numeracao);
 
@@ -118,7 +118,7 @@ public class AtendimentoService {
         repository.deleteById(atendimentoId);
     }
 
-    public Long gerarProximaNumeracao(UUID profissionalId, LocalDate data) {
+    public String gerarProximaNumeracao(UUID profissionalId, LocalDate data) {
         Long maiorNumeracao = repository.findMaxNumeracaoByMesAndAno(
                 data.getMonthValue(),
                 data.getYear(),
@@ -126,7 +126,7 @@ public class AtendimentoService {
 
         long numeracaoAtual = (maiorNumeracao != null) ? maiorNumeracao : 0L;
 
-        return numeracaoAtual + 1;
+        return String.valueOf(numeracaoAtual + 1);
     }
 
     @Transactional(readOnly = false)

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AuthService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService{
         ProfissionalSaude usuario = profissionalRepository.findByEmailIgnoreCase(emailSanitizado)
                 .orElseThrow(() -> new BadCredentialsException(MSG_CREDENCIAIS_INVALIDAS));
 
-        if (!"ATIVO".equalsIgnoreCase(usuario.getStatus())) {
+        if (!Boolean.TRUE.equals(usuario.getAtivo())) {
             throw new BadCredentialsException(MSG_CREDENCIAIS_INVALIDAS);
         }
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ProfissionalSaudeService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ProfissionalSaudeService.java
@@ -58,7 +58,7 @@ public class ProfissionalSaudeService {
     }
 
     public List<PacienteResponseDTO> getPacientesDoProfissional(UUID id) {
-        List<Paciente> pacientes = pacienteRepository.findByProfissionais_Id(id);
+        List<Paciente> pacientes = pacienteRepository.findByProfissionalId(id);
 
         return pacientes.stream()
                 .map(paciente -> {
@@ -69,19 +69,10 @@ public class ProfissionalSaudeService {
     }
 
     public List<PacienteOptionDTO> getPacienteOption(UUID profissionalId) {
-        List<Paciente> pacientes = pacienteRepository.findByProfissionais_Id(profissionalId);
+        List<Paciente> pacientes = pacienteRepository.findByProfissionalId(profissionalId);
         return pacientes.stream()
                 .map(paciente -> pacienteMapper.toOptionDTO(paciente))
                 .collect(toList());
-    }
-
-    public String getPrimeiroNome(UUID id) {
-        String nomeCompleto = repository.findNomeCompletoById(id);
-        if (nomeCompleto == null || nomeCompleto.isBlank()) {
-            return "Doutor(a)";
-        }
-        // Pega a primeira palavra do nome completo
-        return nomeCompleto.trim().split("\\s+")[0];
     }
 
     @Transactional(readOnly = true)

--- a/backend/atendimento/src/main/resources/data-test.sql
+++ b/backend/atendimento/src/main/resources/data-test.sql
@@ -1,4 +1,4 @@
-INSERT INTO vw_pacientes (id, nome, cpf, data_nascimento, contato, cidade, rua, bairro, numero_casa, responsaveis, transtornos, ativo)
+INSERT INTO vw_pacientes (paciente_id, nome, cpf, data_nascimento, contato, cidade, rua, bairro, numero_casa, responsaveis, transtornos)
 VALUES (
            'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
            'João Pedro Silva',
@@ -10,8 +10,7 @@ VALUES (
            'Centro',
            123,
            ARRAY['Maria Silva', 'José Silva'],
-           ARRAY['TEA', 'TDAH'],
-           true
+           ARRAY['TEA', 'TDAH']
        ),
        (
            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
@@ -24,11 +23,10 @@ VALUES (
            'morro',
            '022',
            ARRAY['Rafaela santos', 'Francisco Alvez'],
-           ARRAY['TDA'],
-           true
+           ARRAY['TDA']
        );
 
-INSERT INTO vw_profissional_saude (id, nome, registro_profissional, especialidade, email, senha, perfil, status)
+INSERT INTO vw_profissional_saude (profissional_saude_id, nome, registro_profissional, especialidade, email, senha, perfil, ativo)
 VALUES (
            '44444444-4444-4444-4444-444444444444',
            'Dr. Luiz Artur',
@@ -37,7 +35,7 @@ VALUES (
            'teste@gmail.com',
            '$2a$10$05v1Sk1c9CnRWX9wOMcYP.eI0buevR1DltWhnE3MUA4Nv5IKDX60O',
            'ROLE_PROFISSIONAL',
-           'ATIVO'
+           true
        );
 
 

--- a/backend/atendimento/src/main/resources/db/migration/V3__fix_views_pacientes_e_profissionais.sql
+++ b/backend/atendimento/src/main/resources/db/migration/V3__fix_views_pacientes_e_profissionais.sql
@@ -1,0 +1,65 @@
+DROP VIEW IF EXISTS atendimento.vw_pacientes;
+DROP VIEW IF EXISTS atendimento.vw_profissional_saude;
+
+CREATE OR REPLACE VIEW atendimento.vw_pacientes AS
+WITH ultimo_cadastro AS (
+   SELECT ca.paciente_id, MAX(ca.ano) AS ano
+   FROM apae_geral.cadastros_anuais ca
+   GROUP BY ca.paciente_id
+),
+responsaveis_por_paciente AS (
+   SELECT r.paciente_id,
+          ARRAY_AGG(DISTINCT r.nome ORDER BY r.nome) AS responsaveis
+   FROM apae_geral.responsaveis r
+   GROUP BY r.paciente_id
+),
+transtornos_por_paciente AS (
+   SELECT ca.paciente_id,
+          ARRAY_AGG(DISTINCT t.nome ORDER BY t.nome) AS transtornos
+   FROM apae_geral.cadastros_anuais ca
+   INNER JOIN ultimo_cadastro uc
+          ON uc.paciente_id = ca.paciente_id AND uc.ano = ca.ano
+   INNER JOIN apae_geral.cadastro_anual_transtorno cat
+          ON cat.cadastro_anual_id = ca.id
+   INNER JOIN apae_geral.transtornos t
+          ON t.id = cat.transtorno_id
+   GROUP BY ca.paciente_id
+)
+SELECT p.id AS paciente_id,
+       p.nome_completo AS nome,
+       p.data_de_nascimento AS data_nascimento,
+       p.cpf,
+       p.contato,
+       pp.profissional_id,
+       e.cidade,
+       e.rua,
+       e.bairro,
+       e.numero AS numero_casa,
+       COALESCE(rp.responsaveis, ARRAY[]::varchar[]) AS responsaveis,
+       COALESCE(tp.transtornos, ARRAY[]::varchar[]) AS transtornos
+FROM apae_geral.pacientes p
+         INNER JOIN atendimento.profissional_paciente pp
+                    ON pp.paciente_id = p.id
+         INNER JOIN apae_geral.enderecos e
+                    ON e.id = p.endereco_id
+         LEFT JOIN responsaveis_por_paciente rp
+                   ON rp.paciente_id = p.id
+         LEFT JOIN transtornos_por_paciente tp
+                   ON tp.paciente_id = p.id
+WHERE p.is_apagado = false;
+
+CREATE OR REPLACE VIEW atendimento.vw_profissional_saude AS
+SELECT pds.id AS profissional_saude_id,
+       u.nome_completo AS nome,
+       u.email,
+       u.senha,
+       u.cargo AS perfil,
+       u.contato,
+       pds.ativo AS ativo,
+       pds.documento_profissional AS registro_profissional,
+       aa.area AS especialidade
+FROM apae_geral.usuarios u
+         INNER JOIN apae_geral.profissionais_da_saude pds
+                    ON pds.usuario_id = u.id
+         INNER JOIN apae_geral.areas_de_atendimento aa
+                    ON aa.area = pds.area_de_atendimento;

--- a/backend/atendimento/src/main/resources/db/migration/V4__fix_profissional_fks.sql
+++ b/backend/atendimento/src/main/resources/db/migration/V4__fix_profissional_fks.sql
@@ -1,0 +1,31 @@
+ALTER TABLE atendimento.profissional_paciente
+DROP CONSTRAINT IF EXISTS fk_pp_profissional;
+
+ALTER TABLE atendimento.profissional_paciente
+    ADD CONSTRAINT fk_pp_profissional
+        FOREIGN KEY (profissional_id)
+            REFERENCES apae_geral.profissionais_da_saude(id);
+
+ALTER TABLE atendimento.atendimento
+DROP CONSTRAINT IF EXISTS fk_atend_profissional;
+
+ALTER TABLE atendimento.atendimento
+    ADD CONSTRAINT fk_atend_profissional
+        FOREIGN KEY (profissional_id)
+            REFERENCES apae_geral.profissionais_da_saude(id);
+
+ALTER TABLE atendimento.agendamento
+DROP CONSTRAINT IF EXISTS fk_agend_profissional;
+
+ALTER TABLE atendimento.agendamento
+    ADD CONSTRAINT fk_agend_profissional
+        FOREIGN KEY (profissional_id)
+            REFERENCES apae_geral.profissionais_da_saude(id);
+
+ALTER TABLE atendimento.anexo
+DROP CONSTRAINT IF EXISTS fk_anexo_prof;
+
+ALTER TABLE atendimento.anexo
+    ADD CONSTRAINT fk_anexo_prof
+        FOREIGN KEY (profissional_id)
+            REFERENCES apae_geral.profissionais_da_saude(id);

--- a/backend/atendimento/src/main/resources/schema.sql
+++ b/backend/atendimento/src/main/resources/schema.sql
@@ -71,6 +71,8 @@ CREATE TABLE IF NOT EXISTS cadastro.profissionais_da_saude (
     id                     UUID         PRIMARY KEY,
     nome                   VARCHAR(255) NOT NULL,
     email                  VARCHAR(255) NOT NULL UNIQUE,
+    senha                  VARCHAR(255),
+    perfil                 VARCHAR(100),
     area_de_atendimento    VARCHAR(255) REFERENCES cadastro.areas_de_atendimento(area) ON UPDATE CASCADE,
     contato                VARCHAR(50)  NOT NULL,
     documento_profissional VARCHAR(100) UNIQUE,
@@ -136,6 +138,29 @@ CREATE TABLE IF NOT EXISTS atendimento.atendimento (
 -- vw_pacientes
 -- Pacientes não apagados com ao menos um vínculo profissional.
 CREATE OR REPLACE VIEW atendimento.vw_pacientes AS
+WITH ultimo_cadastro AS (
+    SELECT ca.paciente_id, MAX(ca.ano) AS ano
+    FROM cadastro.cadastros_anuais ca
+    GROUP BY ca.paciente_id
+),
+responsaveis_por_paciente AS (
+    SELECT r.paciente_id,
+           ARRAY_AGG(DISTINCT r.nome ORDER BY r.nome) AS responsaveis
+    FROM cadastro.responsaveis r
+    GROUP BY r.paciente_id
+),
+transtornos_por_paciente AS (
+    SELECT ca.paciente_id,
+           ARRAY_AGG(DISTINCT t.nome ORDER BY t.nome) AS transtornos
+    FROM cadastro.cadastros_anuais ca
+             INNER JOIN ultimo_cadastro uc
+                        ON uc.paciente_id = ca.paciente_id AND uc.ano = ca.ano
+             INNER JOIN cadastro.cadastro_anual_transtorno cat
+                        ON cat.cadastro_anual_id = ca.id
+             INNER JOIN cadastro.transtornos t
+                        ON t.id = cat.transtorno_id
+    GROUP BY ca.paciente_id
+)
 SELECT
     p.id                 AS paciente_id,
     p.nome_completo      AS nome,
@@ -143,9 +168,19 @@ SELECT
     p.cpf                AS cpf,
     p.contato            AS contato,
     p.is_apagado         AS is_apagado,
-    p.endereco_id        AS endereco_id
+    p.endereco_id        AS endereco_id,
+    pp.profissional_id   AS profissional_id,
+    e.cidade             AS cidade,
+    e.rua                AS rua,
+    e.bairro             AS bairro,
+    e.numero             AS numero_casa,
+    COALESCE(rp.responsaveis, ARRAY[]::varchar[]) AS responsaveis,
+    COALESCE(tp.transtornos, ARRAY[]::varchar[])  AS transtornos
 FROM cadastro.pacientes p
          INNER JOIN cadastro.profissional_paciente pp ON pp.paciente_id = p.id
+         INNER JOIN cadastro.enderecos e ON e.id = p.endereco_id
+         LEFT JOIN responsaveis_por_paciente rp ON rp.paciente_id = p.id
+         LEFT JOIN transtornos_por_paciente tp ON tp.paciente_id = p.id
 WHERE p.is_apagado = false;
 
 -- vw_enderecos_paciente
@@ -173,8 +208,8 @@ FROM cadastro.responsaveis r
 -- Transtornos concatenados do cadastro anual mais recente por paciente.
 CREATE OR REPLACE VIEW atendimento.vw_transtornos_paciente AS
 SELECT
-    vp.paciente_id                                   AS paciente_id,
-    STRING_AGG(t.nome, ', ' ORDER BY t.nome)         AS transtornos
+    vp.paciente_id                                      AS paciente_id,
+    ARRAY_AGG(DISTINCT t.nome ORDER BY t.nome)          AS transtornos
 FROM atendimento.vw_pacientes vp
          INNER JOIN cadastro.cadastros_anuais ca
                     ON  ca.paciente_id = vp.paciente_id
@@ -195,7 +230,11 @@ SELECT
     ps.id                  AS profissional_saude_id,
     ps.nome                AS nome,
     ps.email               AS email,
-    ps.ativo               AS status,
+    ps.senha               AS senha,
+    ps.perfil              AS perfil,
+    ps.contato             AS contato,
+    ps.ativo               AS ativo,
+    ps.documento_profissional AS registro_profissional,
     ps.area_de_atendimento AS especialidade_id,
     at.area                AS especialidade
 FROM cadastro.profissionais_da_saude ps

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceIntegrationTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceIntegrationTest.java
@@ -74,8 +74,8 @@ class AtendimentoServiceIntegrationTest {
 
         assertNotNull(created1);
         assertNotNull(created2);
-        assertEquals(1L, created1.numeracao());
-        assertEquals(2L, created2.numeracao());
+        assertEquals("1", created1.numeracao());
+        assertEquals("2", created2.numeracao());
 
         AtendimentoRequestDTO editRequest = new AtendimentoRequestDTO(
                 paciente.getId(),

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AuthServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AuthServiceTest.java
@@ -43,7 +43,7 @@ class AuthServiceTest {
         ProfissionalSaude usuario = mock(ProfissionalSaude.class);
 
         when(profissionalRepository.findByEmailIgnoreCase("user@email.com")).thenReturn(Optional.of(usuario));
-        when(usuario.getStatus()).thenReturn("ATIVO");
+        when(usuario.getAtivo()).thenReturn(true);
         when(usuario.getSenha()).thenReturn("hash");
         when(passwordEncoder.matches("senha123", "hash")).thenReturn(true);
         when(jwtService.gerarToken(usuario)).thenReturn("jwt-token");
@@ -77,7 +77,7 @@ class AuthServiceTest {
         ProfissionalSaude usuario = mock(ProfissionalSaude.class);
 
         when(profissionalRepository.findByEmailIgnoreCase("user@email.com")).thenReturn(Optional.of(usuario));
-        when(usuario.getStatus()).thenReturn("INATIVO");
+        when(usuario.getAtivo()).thenReturn(false);
 
         BadCredentialsException ex = assertThrows(BadCredentialsException.class,
                 () -> authService.autenticar(requestDTO));
@@ -94,7 +94,7 @@ class AuthServiceTest {
         ProfissionalSaude usuario = mock(ProfissionalSaude.class);
 
         when(profissionalRepository.findByEmailIgnoreCase("user@email.com")).thenReturn(Optional.of(usuario));
-        when(usuario.getStatus()).thenReturn("ATIVO");
+        when(usuario.getAtivo()).thenReturn(true);
         when(usuario.getSenha()).thenReturn("hash");
         when(passwordEncoder.matches("senhaErrada", "hash")).thenReturn(false);
 

--- a/frontend/atendimento-app/src/features/agenda/types.ts
+++ b/frontend/atendimento-app/src/features/agenda/types.ts
@@ -6,7 +6,7 @@ export interface Agendamento {
   nomeProfissional: string;
   data: string;
   horario: string;
-  numeracao: number;
+  numeracao: string;
   status: boolean;
 }
 
@@ -18,7 +18,7 @@ export interface AgendamentoResponse {
   nomeProfissional: string;
   data: string;
   time: string;
-  numeroAtendimento: number;
+  numeroAtendimento: string;
   status: boolean;
 }
 

--- a/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
+++ b/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
@@ -16,7 +16,7 @@ export function normalizarAgendamentos(
         nomeProfissional: a.nomeProfissional || "Não informado",
         horario: a.time,
         data: isoParaBR(a.data),
-        numeracao: a.numeroAtendimento ?? 0,
+        numeracao: String(a.numeroAtendimento ?? "0"),
         status: a.status,
       });
     });

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoCard.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoCard.tsx
@@ -9,7 +9,7 @@ interface AtendimentoCardProps {
   id: string;
   data: string;
   hora: string;
-  numeracao: number;
+  numeracao: string;
   status: boolean; 
   relatorio?: Relatorio[];
   atendimentos: Atendimento[];

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoDetailsModal.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoDetailsModal.tsx
@@ -16,7 +16,7 @@ interface AtendimentoDetailsModalProps {
   atendimentoId: string;
   data: string;
   hora: string;
-  numeracao: number;
+  numeracao: string;
   relatorios?: Relatorio[];
   atendimentos: Atendimento[];
   status: boolean;

--- a/frontend/atendimento-app/src/features/atendimento/components/atendimentoForm.tsx
+++ b/frontend/atendimento-app/src/features/atendimento/components/atendimentoForm.tsx
@@ -26,7 +26,7 @@ interface AtendimentoFormProps {
 interface AtendimentoFormValues {
   data: string;
   hora: string;
-  numeracao: number;
+  numeracao: string;
   relatorio: {
     titulo: string;
     descricao: string;
@@ -55,7 +55,7 @@ export default function AtendimentoForm({
         ? {
             data: brParaISO(atendimentoEditavel.data.replace(/\//g, "-")),
             hora: atendimentoEditavel.hora,
-            numeracao: atendimentoEditavel.numeracao,
+            numeracao: String(atendimentoEditavel.numeracao),
             relatorio: atendimentoEditavel.relatorio.map((r) => ({
               titulo: r.titulo,
               descricao: r.descricao,
@@ -67,7 +67,7 @@ export default function AtendimentoForm({
               hour: "2-digit",
               minute: "2-digit",
             }),
-            numeracao: 1,
+            numeracao: "1",
             relatorio: [{ titulo: "", descricao: "" }],
           },
     });
@@ -115,7 +115,7 @@ export default function AtendimentoForm({
       const dataOriginalISO = brParaISO(atendimentoEditavel.data);
 
       if (dataSelecionada === dataOriginalISO) {
-        setValue("numeracao", atendimentoEditavel.numeracao);
+        setValue("numeracao", String(atendimentoEditavel.numeracao));
         return;
       }
     }
@@ -130,7 +130,7 @@ export default function AtendimentoForm({
       return mesBR === mes && anoBR === ano;
     });
 
-    setValue("numeracao", atendimentosDoMes.length + 1);
+    setValue("numeracao", String(atendimentosDoMes.length + 1));
   }, [dataSelecionada, atendimentos, atendimentoEditavel, setValue]);
 
   const { fields, append, remove } = useFieldArray({
@@ -198,7 +198,7 @@ export default function AtendimentoForm({
             type="number"
             required
             disabled
-            {...register("numeracao", { valueAsNumber: true })}
+            {...register("numeracao")}
             className="rounded-[30px] border-[#B2D7EC] focus-visible:ring-0 focus-visible:border-[#B2D7EC] text-center"
           />
         </div>

--- a/frontend/atendimento-app/src/features/atendimento/types.ts
+++ b/frontend/atendimento-app/src/features/atendimento/types.ts
@@ -8,7 +8,7 @@ export interface Atendimento {
   id: string;
   data: string;
   hora: string;
-  numeracao: number;
+  numeracao: string;
   status: boolean;
   relatorio: Relatorio[];
 }
@@ -17,7 +17,7 @@ export interface AtendimentoPayload {
   pacienteId: string;
   data: string;
   hora: string;
-  numeracao?: number;
+  numeracao?: string;
   relatorio: Omit<Relatorio, "id">[];
 }
 

--- a/frontend/atendimento-app/src/features/home/hooks/useHome.ts
+++ b/frontend/atendimento-app/src/features/home/hooks/useHome.ts
@@ -1,11 +1,11 @@
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
 import { getPacientes, FiltroPaciente } from "../services/homeService";
-import { usePrimeiroNomeProfissional } from "@/features/profissional/hooks/usePrimeiroNomeProfissional";
+import { useProfissional } from "@/features/profissional/hooks/useProfissional";
 import { useDebounce } from "@/utils/useDebounce";
 
 export function useHome() {
-  const { data: medicoNome, isLoading: loadingNome } = usePrimeiroNomeProfissional();
+  const { data: profissional, isLoading: loadingNome } = useProfissional();
 
   const [busca, setBusca] = useState("");
   const [filtro, setFiltro] = useState<"nome" | "cpf" | "cidade">("nome");
@@ -41,7 +41,7 @@ export function useHome() {
   });
 
   return {
-    medicoNome: medicoNome ?? "Profissional",
+    medicoNome: profissional?.nomeCompleto?.trim().split(/\s+/)[0] ?? "Profissional",
     pacientes: paginatedData?.data || [],
     pagination: paginatedData?.pagination,
     loading: loadingNome || loadingPacientes,

--- a/frontend/atendimento-app/src/features/profissional/hooks/usePrimeiroNomeProfissional.ts
+++ b/frontend/atendimento-app/src/features/profissional/hooks/usePrimeiroNomeProfissional.ts
@@ -1,9 +1,0 @@
-import { useQuery } from "@tanstack/react-query";
-import { getPrimeiroNomeProfissional } from "../services/profissionalService";
-
-export function usePrimeiroNomeProfissional() {
-  return useQuery({
-    queryKey: ["profissional", "primeiro-nome"],
-    queryFn: getPrimeiroNomeProfissional,
-  });
-}

--- a/frontend/atendimento-app/src/features/profissional/services/profissionalService.ts
+++ b/frontend/atendimento-app/src/features/profissional/services/profissionalService.ts
@@ -8,11 +8,3 @@ export async function getProfissional(): Promise<Profissional> {
 
   return data;
 }
-
-export async function getPrimeiroNomeProfissional(): Promise<string> {
-  const { data } = await api.get<string>(
-    `/profissionais/primeiro-nome`
-  );
-
-  return data;
-}

--- a/frontend/atendimento-app/src/features/profissional/types.ts
+++ b/frontend/atendimento-app/src/features/profissional/types.ts
@@ -1,6 +1,5 @@
 export interface Profissional {
   id: string;
-  primeiroNome: string;
   nomeCompleto: string;
   email: string;
   contato: string;


### PR DESCRIPTION
## Contexto
Esta PR refatora o modelo JPA do módulo de Atendimento para alinhar as entidades ao novo modelo de banco, onde dados de pacientes e profissionais de saúde vêm do schema `apae_geral` por meio de views somente leitura no schema `atendimento`.

## O que foi feito
- Mapeia `Paciente` para `atendimento.vw_pacientes` como entidade `@Immutable`.
- Mapeia `ProfissionalSaude` para `atendimento.vw_profissional_saude` como entidade `@Immutable`.
- Remove relacionamentos bidirecionais antigos e campos incompatíveis com views locais.
- Adiciona a migration `V3` para recriar as views de pacientes e profissionais.
- Ajusta `vw_pacientes` para retornar `responsaveis` e `transtornos` como arrays agregados.
- Ajusta `vw_profissional_saude` para expor dados vindos de `usuarios` e `profissionais_da_saude`.
- Corrige mapeamentos de entidades próprias do schema `atendimento`.
- Altera `numeracao` para `String` onde a migration usa `VARCHAR(50)`.
- Remove uso de `primeiroNome` e adapta o frontend para derivar o nome a partir de `nomeCompleto`.

## Validação
- Conferidas buscas residuais para garantir ausência de:
  - `primeiroNome`
  - `firebaseUID`
  - `findByProfissionais_Id`
  - `atendimeto_id`
  - asserts antigos de `numeracao` como `Long`
- Validada a V3 no banco após ajuste de `u.cargo AS perfil`.
- Executado lint do frontend com 0 erros.

## Observações
- `responsaveis` e `transtornos` agora são dados estruturados vindos da view, evitando strings concatenadas.
- A view de profissionais usa `documento_profissional AS registro_profissional`, conforme arquitetura do banco.