### PR TITLE
refactor: refatora atendimento para views imutáveis e remove acoplamento com Firebase (#307)

### DIFF
--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/ArquivoController.java
@@ -81,8 +81,11 @@ public class ArquivoController {
     }
 
     @DeleteMapping("/delete")
-    public ResponseEntity<Void> delete(@RequestParam(name = "objectName") String objectName){
-        service.deletar(objectName);
+    public ResponseEntity<Void> delete(
+            @RequestParam(name = "objectName") String objectName,
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
+        service.deletar(objectName, usuarioAutenticado.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/AtendimentoController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/AtendimentoController.java
@@ -4,8 +4,6 @@ import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
 import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
 import br.org.apae.atendimento.dtos.response.MesAnoAtendimentoResponseDTO;
 import br.org.apae.atendimento.services.AtendimentoService;
-import br.org.apae.atendimento.services.PacienteService;
-import br.org.apae.atendimento.services.ProfissionalSaudeService;
 
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,12 +23,6 @@ public class AtendimentoController {
 
     @Autowired
     private AtendimentoService atendimentoService;
-
-    @Autowired
-    private PacienteService pacienteService;
-
-    @Autowired
-    private ProfissionalSaudeService profissionalSaudeService;
 
     @PostMapping
     public ResponseEntity<AtendimentoResponseDTO> criarAtendimento(

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/PacienteController.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/controllers/PacienteController.java
@@ -23,14 +23,19 @@ public class PacienteController {
     private PacienteService pacienteService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<PacienteResponseDTO> buscarPorId(@PathVariable UUID id) {
-        PacienteResponseDTO paciente = pacienteService.getPaciente(id);
-        return ResponseEntity.ok(paciente);
+    public ResponseEntity<PacienteResponseDTO> buscarPorId(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
+        return ResponseEntity.ok(pacienteService.getPaciente(id, usuarioAutenticado.getId()));
     }
 
     @GetMapping("/{id}/nome-completo")
-    public ResponseEntity<String> obterPrimeiroNome(@PathVariable UUID id) {
-        String nome = pacienteService.getNomeCompletoPacienteById(id);
+    public ResponseEntity<String> obterNomeCompleto(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
+        String nome = pacienteService.getNomeCompletoPacienteById(id, usuarioAutenticado.getId());
         return ResponseEntity.ok().body(nome);
     }
     
@@ -50,15 +55,20 @@ public class PacienteController {
        return ResponseEntity.ok(paciente);
    }
 
-   @PostMapping("/{pacienteId}")
-   public ResponseEntity<String> adicionarFoto(@RequestPart("foto") MultipartFile foto, @PathVariable UUID pacienteId){
-        String urlFoto = pacienteService.adicionarFoto(foto, pacienteId);
+    @PostMapping("/{pacienteId}")
+    public ResponseEntity<String> adicionarFoto(
+            @RequestPart("foto") MultipartFile foto,
+            @PathVariable UUID pacienteId,
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
+        String urlFoto = pacienteService.adicionarFoto(foto, pacienteId, usuarioAutenticado.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(urlFoto);
+    }
 
-        return  ResponseEntity.status(HttpStatus.CREATED).body(urlFoto);
-   }
-
-   @GetMapping("/dropdown")
-   public ResponseEntity<List<PacienteDropdownResponseDTO>> listarParaDropdown() {
-        return ResponseEntity.ok(pacienteService.listarParaDropdown());
-   }
+    @GetMapping("/dropdown")
+    public ResponseEntity<List<PacienteDropdownResponseDTO>> listarParaDropdown(
+            @AuthenticationPrincipal UsuarioAutenticado usuarioAutenticado
+    ) {
+        return ResponseEntity.ok(pacienteService.listarParaDropdown(usuarioAutenticado.getId()));
+    }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
@@ -5,11 +5,11 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 public record AgendamentoResponseDTO(
-        UUID atendimentoId,
+        UUID id,
         UUID pacienteId,
         String nomePaciente,
         LocalDate data,
-        LocalTime time,
-        String numeroAtendimento,
+        LocalTime hora,
+        String numeracao,
         boolean status) {
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Agendamento.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Agendamento.java
@@ -29,11 +29,17 @@ public class Agendamento {
     @Column(name = "numeracao")
     private String numeracao;
 
-    @ManyToOne
-    @JoinColumn(name = "profissional_id")
+    @Column(name = "profissional_id", nullable = false)
+    private UUID profissionalId;
+
+    @Column(name = "paciente_id", nullable = false)
+    private UUID pacienteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profissional_id", insertable = false, updatable = false)
     private ProfissionalSaude profissional;
 
-    @ManyToOne
-    @JoinColumn(name = "paciente_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", insertable = false, updatable = false)
     private Paciente paciente;
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Arquivo.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 
 @Entity
@@ -43,13 +44,19 @@ public class Arquivo {
     @JoinColumn(name = "tipo_id", nullable = false)
     private TipoArquivo tipo;
 
+    @Column(name = "profissional_id", nullable = false)
+    private UUID profissionalId;
+
+    @Column(name = "paciente_id", nullable = false)
+    private UUID pacienteId;
+
     @JsonIgnore
-    @ManyToOne
-    @JoinColumn(name = "profissional_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profissional_id", insertable = false, updatable = false)
     private ProfissionalSaude profissional;
 
     @JsonIgnore
-    @ManyToOne
-    @JoinColumn(name = "paciente_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", insertable = false, updatable = false)
     private Paciente paciente;
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Atendimento.java
@@ -29,12 +29,18 @@ public class Atendimento {
     @Column(name = "numeracao")
     private String numeracao;
 
-    @ManyToOne
-    @JoinColumn(name = "paciente_id")
+    @Column(name = "paciente_id", nullable = false)
+    private UUID pacienteId;
+
+    @Column(name = "profissional_id", nullable = false)
+    private UUID profissionalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", insertable = false, updatable = false)
     private Paciente paciente;
 
-    @ManyToOne
-    @JoinColumn(name = "profissional_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profissional_id", insertable = false, updatable = false)
     private ProfissionalSaude profissional;
 
     @Column(name = "status")

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Paciente.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/entities/Paciente.java
@@ -60,4 +60,7 @@ public class Paciente {
     @JsonIgnore
     private String fotoPreAssinada;
 
+    @Column(name = "profissional_id")
+    private UUID profissionalId;
+
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
@@ -3,20 +3,18 @@ package br.org.apae.atendimento.mappers;
 import br.org.apae.atendimento.dtos.request.AgendamentoRequestDTO;
 import br.org.apae.atendimento.dtos.response.AgendamentoResponseDTO;
 import br.org.apae.atendimento.entities.Agendamento;
-import br.org.apae.atendimento.entities.Atendimento;
-import br.org.apae.atendimento.entities.Paciente;
-import br.org.apae.atendimento.entities.ProfissionalSaude;
-import org.bouncycastle.asn1.ocsp.Request;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
 @Component
 public class AgendamentoMapper extends AbstractMapper<Agendamento, AgendamentoRequestDTO, AgendamentoResponseDTO> {
+
     @Override
     public Agendamento toEntityPadrao(AgendamentoRequestDTO dtoPadrao) {
         Agendamento agendamento = new Agendamento();
 
+        agendamento.setPacienteId(dtoPadrao.pacienteId());
         agendamento.setDataHora(LocalDateTime.of(dtoPadrao.data(), dtoPadrao.hora()));
         agendamento.setStatus(false);
 
@@ -24,18 +22,19 @@ public class AgendamentoMapper extends AbstractMapper<Agendamento, AgendamentoRe
     }
 
     @Override
-    public AgendamentoResponseDTO toDTOPadrao(Agendamento entidadePadrao) {
+    public AgendamentoResponseDTO toDTOPadrao(Agendamento agendamento) {
+        String nomePaciente = agendamento.getPaciente() != null
+                ? agendamento.getPaciente().getNomeCompleto()
+                : null;
 
         return new AgendamentoResponseDTO(
-                entidadePadrao.getId(),
-                entidadePadrao.getPaciente().getId(),
-                entidadePadrao.getPaciente().getNomeCompleto(),
-                entidadePadrao.getDataHora().toLocalDate(),
-                entidadePadrao.getDataHora().toLocalTime(),
-                entidadePadrao.getNumeracao(),
-                entidadePadrao.isStatus()
+                agendamento.getId(),
+                agendamento.getPacienteId(),
+                nomePaciente,
+                agendamento.getDataHora().toLocalDate(),
+                agendamento.getDataHora().toLocalTime(),
+                agendamento.getNumeracao(),
+                agendamento.isStatus()
         );
     }
-
-
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ArquivoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/ArquivoMapper.java
@@ -1,30 +1,21 @@
 package br.org.apae.atendimento.mappers;
+
 import br.org.apae.atendimento.dtos.request.ArquivoRequestDTO;
 import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
 import br.org.apae.atendimento.entities.Arquivo;
 import br.org.apae.atendimento.entities.TipoArquivo;
-import br.org.apae.atendimento.repositories.PacienteRepository;
 import br.org.apae.atendimento.utils.StringSanitizer;
 
 import org.springframework.stereotype.Component;
 
-import br.org.apae.atendimento.entities.Paciente;
-
 @Component
 public class ArquivoMapper extends AbstractMapper<Arquivo, ArquivoRequestDTO, ArquivoResponseDTO> {
-
-    private final PacienteRepository pacienteRepository;
-
-    public ArquivoMapper(PacienteRepository pacienteRepository) {
-        this.pacienteRepository = pacienteRepository;
-    }
 
     @Override
     public Arquivo toEntityPadrao(ArquivoRequestDTO dto) {
         Arquivo arquivo = new Arquivo();
 
-        Paciente paciente = pacienteRepository.getReferenceById(dto.pacienteId());
-        arquivo.setPaciente(paciente);
+        arquivo.setPacienteId(dto.pacienteId());
 
         TipoArquivo tipoArquivo = new TipoArquivo();
         tipoArquivo.setId(dto.tipoArquivo());
@@ -34,8 +25,8 @@ public class ArquivoMapper extends AbstractMapper<Arquivo, ArquivoRequestDTO, Ar
         arquivo.setTitulo(StringSanitizer.sanitize(tituloLimpo));
         arquivo.setTituloCanonical(StringSanitizer.canonicalize(dto.titulo()));
 
-        String descLimpa = StringSanitizer.sanitize(StringSanitizer.normalize(dto.descricao()));
-        arquivo.setDescricao(descLimpa);
+        String descLimpa = StringSanitizer.normalize(dto.descricao());
+        arquivo.setDescricao(StringSanitizer.sanitize(descLimpa));
 
         arquivo.setData(dto.data());
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AtendimentoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AtendimentoMapper.java
@@ -3,40 +3,26 @@ package br.org.apae.atendimento.mappers;
 import br.org.apae.atendimento.dtos.request.AtendimentoRequestDTO;
 import br.org.apae.atendimento.dtos.response.TopicoResponseDTO;
 import br.org.apae.atendimento.entities.Topico;
-import br.org.apae.atendimento.repositories.PacienteRepository;
 import org.springframework.stereotype.Component;
 
 import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
 import br.org.apae.atendimento.entities.Atendimento;
-import br.org.apae.atendimento.entities.Paciente;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
 public class AtendimentoMapper extends AbstractMapper<Atendimento, AtendimentoRequestDTO, AtendimentoResponseDTO> {
 
-    private final PacienteRepository pacienteRepository;
-
-    public AtendimentoMapper(PacienteRepository pacienteRepository) {
-        this.pacienteRepository = pacienteRepository;
-    }
-
     @Override
-    public Atendimento toEntityPadrao(AtendimentoRequestDTO dtoPadraoAtendimento) {
+    public Atendimento toEntityPadrao(AtendimentoRequestDTO dto) {
         Atendimento atendimento = new Atendimento();
 
-        Paciente paciente = pacienteRepository.getReferenceById(dtoPadraoAtendimento.pacienteId());
+        atendimento.setPacienteId(dto.pacienteId());
+        atendimento.setDataAtendimento(LocalDateTime.of(dto.data(), dto.hora()));
 
-        LocalDateTime dataAtendimento = LocalDateTime.of(dtoPadraoAtendimento.data(), dtoPadraoAtendimento.hora());
-
-        atendimento.setDataAtendimento(dataAtendimento);
-        atendimento.setPaciente(paciente);
-
-        List<Topico> relatorio = dtoPadraoAtendimento.relatorio().stream()
+        List<Topico> relatorio = dto.relatorio().stream()
                 .map(t -> {
                     Topico topico = new Topico();
                     topico.setTitulo(t.titulo());
@@ -54,7 +40,11 @@ public class AtendimentoMapper extends AbstractMapper<Atendimento, AtendimentoRe
     @Override
     public AtendimentoResponseDTO toDTOPadrao(Atendimento entidadePadraoAtendimento) {
         List<TopicoResponseDTO> relatorio = entidadePadraoAtendimento.getRelatorio().stream()
-                .map(t -> new TopicoResponseDTO(t.getId(), t.getTitulo(),t.getDescricao()))
+                .map(t -> new TopicoResponseDTO(
+                        t.getId(),
+                        t.getTitulo(),
+                        t.getDescricao()
+                ))
                 .collect(Collectors.toList());
 
         return new AtendimentoResponseDTO(

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AgendamentoRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AgendamentoRepository.java
@@ -2,12 +2,10 @@ package br.org.apae.atendimento.repositories;
 
 import br.org.apae.atendimento.entities.Agendamento;
 
-import br.org.apae.atendimento.entities.Atendimento;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -15,18 +13,27 @@ import java.util.UUID;
 
 public interface AgendamentoRepository extends JpaRepository<Agendamento, UUID> {
     List<Agendamento> findByProfissionalIdOrderByDataHora(UUID profissionalId);
+
     @Query("""
-       SELECT a 
+       SELECT a
        FROM Agendamento a
        WHERE a.dataHora >= :dataInicio
-         AND a.dataHora <  :dataFim
-         AND a.paciente.id = :pacienteId
+         AND a.dataHora < :dataFim
+         AND a.profissionalId = :profissionalId
+         AND a.pacienteId = :pacienteId
     """)
-    Optional<Agendamento> findByDataHoraAndPacienteId(
+    Optional<Agendamento> findByDataHoraAndProfissionalIdAndPacienteId(
             @Param("dataInicio") LocalDateTime dataInicio,
             @Param("dataFim") LocalDateTime dataFim,
+            @Param("profissionalId") UUID profissionalId,
             @Param("pacienteId") UUID pacienteId
     );
 
     boolean existsByProfissionalIdAndDataHora(UUID profissionalId, LocalDateTime dataHora);
+
+    Optional<Agendamento> findByIdAndProfissionalIdAndPacienteId(
+            UUID id,
+            UUID profissionalId,
+            UUID pacienteId
+    );
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AnexoRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AnexoRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -17,4 +18,6 @@ public interface AnexoRepository extends JpaRepository<Arquivo, String> {
             LocalDate data,
             Long tipoId
     );
+
+    Optional<Arquivo> findByObjectNameAndProfissionalId(String objectName, UUID profissionalId);
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/AtendimentoRepository.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 
 @Repository
 public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> {
-    List<Atendimento> findByPacienteIdAndProfissionalIdOrderByDataAtendimento(UUID pacienteId, UUID profissionalId);
 
     @Query(value = """
         SELECT MAX(CAST(numeracao AS BIGINT))
@@ -31,8 +30,8 @@ public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> 
         SELECT DISTINCT a
         FROM Atendimento a
         LEFT JOIN FETCH a.relatorio
-        WHERE a.paciente.id = :pacienteid
-            AND a.profissional.id = :profissionalid
+        WHERE a.pacienteId = :pacienteid
+            AND a.profissionalId = :profissionalid
         ORDER BY a.dataAtendimento
     """)
     List<Atendimento> findByPacienteIdAndProfissionalIdComRelatorio(
@@ -53,8 +52,8 @@ public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> 
         FROM Atendimento a
         WHERE a.dataAtendimento >= :inicioDia
           AND a.dataAtendimento < :fimDia
-          AND a.profissional.id = :profissionalId
-          AND a.paciente.id = :pacienteId
+          AND a.profissionalId = :profissionalId
+          AND a.pacienteId = :pacienteId
     """)
     boolean existsAtendimentoNoDia(
             LocalDateTime inicioDia,
@@ -68,7 +67,19 @@ public interface AtendimentoRepository extends JpaRepository<Atendimento, UUID> 
             LocalDateTime dataAtendimento
     );
 
+    Optional<Atendimento> findByIdAndProfissionalIdAndPacienteId(
+            UUID id,
+            UUID profissionalId,
+            UUID pacienteId
+    );
+
     @Modifying
-    @Query("UPDATE Atendimento a SET a.status = true WHERE a.id = :id")
-    void concluirAtendimento(@Param("id") UUID id);
+    @Query("""
+    UPDATE Atendimento a
+    SET a.status = true
+    WHERE a.id = :id
+      AND a.profissionalId = :profissionalId
+""")
+    int concluirAtendimento(@Param("id") UUID id, @Param("profissionalId") UUID profissionalId);
+
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/PacienteRepository.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/repositories/PacienteRepository.java
@@ -10,11 +10,23 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import br.org.apae.atendimento.entities.Paciente;
 
 @Repository
 public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
+
+    @Query(value = """
+    SELECT vp.*
+    FROM atendimento.vw_pacientes vp
+    WHERE vp.paciente_id = :id
+      AND vp.profissional_id = :profissionalId
+""", nativeQuery = true)
+    Optional<Paciente> findByIdAndProfissionalId(
+            @Param("id") UUID id,
+            @Param("profissionalId") UUID profissionalId
+    );
 
     @Query(value = "SELECT CASE WHEN COUNT(1) > 0 THEN true ELSE false END " +
             "FROM atendimento.profissional_paciente pp " +
@@ -23,31 +35,32 @@ public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
     boolean existeRelacao(@Param("pacienteId") UUID pacienteId, @Param("profissionalId") UUID profissionalId);
 
     @Query("""
-        SELECT p.nomeCompleto
-        FROM Paciente p
-        WHERE p.id = :pacienteId
-        """)
-    String findNomeCompletoById(@Param("pacienteId") UUID pacienteId);
+    SELECT p.nomeCompleto
+    FROM Paciente p
+    WHERE p.id = :pacienteId
+      AND p.profissionalId = :profissionalId
+""")
+    String findNomeCompletoByIdAndProfissionalId(
+            @Param("pacienteId") UUID pacienteId,
+            @Param("profissionalId") UUID profissionalId
+    );
 
     @Query(value = "SELECT vp.* FROM atendimento.vw_pacientes vp " +
-            "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
-            "WHERE pp.profissional_id = :profissionalId",
+            "WHERE vp.profissional_id = :profissionalId",
             nativeQuery = true)
     List<Paciente> findByProfissionalId(@Param("profissionalId") UUID profissionalId);
 
     @Query(value = "" +
             "SELECT DISTINCT vp.* " +
             "FROM atendimento.vw_pacientes vp " +
-            "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
-            "WHERE pp.profissional_id = :profissionalId " +
+            "WHERE vp.profissional_id = :profissionalId " +
             "  AND (:nome IS NULL OR LOWER(vp.nome) LIKE CONCAT('%', LOWER(:nome), '%')) " +
             "  AND (:cpf IS NULL OR vp.cpf LIKE CONCAT('%', :cpf, '%')) " +
             "  AND (:cidade IS NULL OR LOWER(vp.cidade) LIKE CONCAT('%', LOWER(:cidade), '%'))",
             countQuery = "" +
                     "SELECT COUNT(DISTINCT vp.paciente_id) " +
                     "FROM atendimento.vw_pacientes vp " +
-                    "JOIN atendimento.profissional_paciente pp ON pp.paciente_id = vp.paciente_id " +
-                    "WHERE pp.profissional_id = :profissionalId " +
+                    "WHERE vp.profissional_id = :profissionalId " +
                     "  AND (:nome IS NULL OR LOWER(vp.nome) LIKE CONCAT('%', LOWER(:nome), '%')) " +
                     "  AND (:cpf IS NULL OR vp.cpf LIKE CONCAT('%', :cpf, '%')) " +
                     "  AND (:cidade IS NULL OR LOWER(vp.cidade) LIKE CONCAT('%', LOWER(:cidade), '%'))",
@@ -60,7 +73,11 @@ public interface PacienteRepository extends JpaRepository<Paciente, UUID> {
             Pageable pageable
     );
 
-    @Query("SELECT new br.org.apae.atendimento.dtos.response.PacienteDropdownResponseDTO(p.id, p.nomeCompleto) " +
-    "FROM Paciente p ORDER BY p.nomeCompleto ASC")
-    List<PacienteDropdownResponseDTO> listarParaDropdown();
+    @Query("""
+    SELECT DISTINCT new br.org.apae.atendimento.dtos.response.PacienteDropdownResponseDTO(p.id, p.nomeCompleto)
+    FROM Paciente p
+    WHERE p.profissionalId = :profissionalId
+    ORDER BY p.nomeCompleto ASC
+""")
+    List<PacienteDropdownResponseDTO> listarParaDropdown(@Param("profissionalId") UUID profissionalId);
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
@@ -4,8 +4,6 @@ import br.org.apae.atendimento.dtos.request.AgendamentoRequestDTO;
 import br.org.apae.atendimento.dtos.response.AgendamentoResponseDTO;
 import br.org.apae.atendimento.dtos.response.DiaAgendamentoResponseDTO;
 import br.org.apae.atendimento.entities.Agendamento;
-import br.org.apae.atendimento.entities.Paciente;
-import br.org.apae.atendimento.entities.ProfissionalSaude;
 import br.org.apae.atendimento.exceptions.invalid.AgendamentoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.AgendamentoNotFoundException;
 import br.org.apae.atendimento.exceptions.invalid.RelacaoInvalidException;
@@ -27,19 +25,16 @@ import java.util.stream.Collectors;
 public class AgendamentoService {
     private AgendamentoRepository repository;
     private PacienteService pacienteService;
-    private ProfissionalSaudeService profissionalSaudeService;
     private AgendamentoMapper agendamentoMapper;
     private AtendimentoRepository atendimentoRepository;
 
     public AgendamentoService(AgendamentoRepository repository,
                               PacienteService pacienteService,
-                              ProfissionalSaudeService profissionalSaudeService,
                               AgendamentoMapper agendamentoMapper,
                               AtendimentoRepository atendimentoRepository) {
 
         this.repository = repository;
         this.pacienteService = pacienteService;
-        this.profissionalSaudeService = profissionalSaudeService;
         this.agendamentoMapper = agendamentoMapper;
         this.atendimentoRepository = atendimentoRepository;
     }
@@ -49,33 +44,44 @@ public class AgendamentoService {
     }
 
     public AgendamentoResponseDTO agendar(AgendamentoRequestDTO agendamentoRequest, UUID profissionalId) {
-        if (verificarAgendamentoExiste(
-                profissionalId,
-                agendamentoRequest.data(), agendamentoRequest.hora())) {
+        if (!pacienteService.existeRelacao(agendamentoRequest.pacienteId(), profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem vinculo com este paciente para criar agendamento.");
+        }
+
+        if (verificarAgendamentoExiste(profissionalId, agendamentoRequest.data(), agendamentoRequest.hora())) {
             throw new AgendamentoInvalidException(
                     agendamentoRequest.data() + " - " + agendamentoRequest.hora() + " ja possui um agendamento");
         }
 
         Agendamento agendamento = agendamentoMapper.toEntityPadrao(agendamentoRequest);
+        agendamento.setProfissionalId(profissionalId);
 
-        ProfissionalSaude profissionalSaude = profissionalSaudeService.getProfissionalById(profissionalId);
-        Paciente paciente = pacienteService.getPacienteById(agendamentoRequest.pacienteId());
-
-        agendamento.setProfissional(profissionalSaude);
-        agendamento.setPaciente(paciente);
-        verificarAtendimentos(agendamentoRequest.data(),
+        verificarAtendimentos(
+                agendamentoRequest.data(),
                 profissionalId,
                 agendamentoRequest.pacienteId(),
-                agendamento);
+                agendamento
+        );
 
         return agendamentoMapper.toDTOPadrao(repository.save(agendamento));
     }
 
-    public Agendamento buscarAgendamentoPorDataEPaciente(LocalDate data, UUID pacienteId) {
+    public Agendamento buscarAgendamentoPorDataProfissionalEPaciente(
+            LocalDate data,
+            UUID profissionalId,
+            UUID pacienteId
+    ) {
         LocalDateTime dataInicio = data.atStartOfDay();
         LocalDateTime dataFim = dataInicio.plusDays(1);
-        return repository.findByDataHoraAndPacienteId(dataInicio, dataFim, pacienteId)
-                .orElseThrow(() -> new AgendamentoNotFoundException("Nenhum agendamento encontrado para esse paciente nesta data."));
+
+        return repository.findByDataHoraAndProfissionalIdAndPacienteId(
+                dataInicio,
+                dataFim,
+                profissionalId,
+                pacienteId
+        ).orElseThrow(() -> new AgendamentoNotFoundException(
+                "Nenhum agendamento encontrado para esse profissional e paciente nesta data."
+        ));
     }
 
 
@@ -95,12 +101,14 @@ public class AgendamentoService {
 
     public void deletar(UUID profissionalId, UUID pacienteId, UUID agendamentoId) {
         if (!pacienteService.existeRelacao(pacienteId, profissionalId)) {
-            throw new RelacaoInvalidException("Você não tem vínculo com este paciente para excluir o agendamento.");
+            throw new RelacaoInvalidException("Voce nao tem vinculo com este paciente para excluir o agendamento.");
         }
-        if (!repository.existsById(agendamentoId)) {
-            throw new AgendamentoNotFoundException("O agendamento que tentou excluir não existe ou já foi apagado.");
-        }
-        repository.deleteById(agendamentoId);
+
+        Agendamento agendamento = repository
+                .findByIdAndProfissionalIdAndPacienteId(agendamentoId, profissionalId, pacienteId)
+                .orElseThrow(() -> new AgendamentoNotFoundException("O agendamento nao existe ou nao pertence ao profissional autenticado."));
+
+        repository.delete(agendamento);
     }
 
     public void setStatus(Agendamento agendamento) {

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
@@ -3,14 +3,13 @@ package br.org.apae.atendimento.services;
 import br.org.apae.atendimento.dtos.request.ArquivoRequestDTO;
 import br.org.apae.atendimento.dtos.response.ArquivoResponseDTO;
 import br.org.apae.atendimento.entities.Arquivo;
-import br.org.apae.atendimento.entities.ProfissionalSaude;
 import br.org.apae.atendimento.entities.TipoArquivo;
 import br.org.apae.atendimento.exceptions.invalid.AtendimentoInvalidException;
+import br.org.apae.atendimento.exceptions.invalid.RelacaoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.ArquivoNotFoundException;
 import br.org.apae.atendimento.exceptions.notfound.TipoArquivoNotFoundException;
 import br.org.apae.atendimento.mappers.ArquivoMapper;
 import br.org.apae.atendimento.repositories.AnexoRepository;
-import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
 import br.org.apae.atendimento.repositories.TipoArquivoRepository;
 import br.org.apae.atendimento.services.storage.ObjectStorageService;
 import br.org.apae.atendimento.services.storage.PresignedUrlService;
@@ -36,10 +35,10 @@ public class ArquivoService {
     private TipoArquivoRepository tipoRepository;
 
     @Autowired
-    private ProfissionalSaudeRepository profissionalRepository;
+    private ObjectStorageService storageService;
 
     @Autowired
-    private ObjectStorageService storageService;
+    private PacienteService pacienteService;
 
     @Autowired
     private PresignedUrlService urlService;
@@ -56,6 +55,10 @@ public class ArquivoService {
 
     @Transactional
     public ArquivoResponseDTO salvar(MultipartFile file, ArquivoRequestDTO arquivoRequest, UUID profissionalId) {
+        if (!pacienteService.existeRelacao(arquivoRequest.pacienteId(), profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem vinculo com este paciente para salvar arquivos.");
+        }
+
         validarIntegridadeArquivo(file);
         validarIntervaloData(arquivoRequest.data());
 
@@ -81,8 +84,7 @@ public class ArquivoService {
         arquivo.setNomeArquivo(nomeSanitizado);
         arquivo.setTipo(tipoArquivo);
 
-        ProfissionalSaude profissionalSaude = profissionalRepository.getReferenceById(profissionalId);
-        arquivo.setProfissional(profissionalSaude);
+        arquivo.setProfissionalId(profissionalId);
 
         Arquivo arquivoPersistido = repository.save(arquivo);
         arquivoPersistido.setPresignedUrl(url);
@@ -91,6 +93,10 @@ public class ArquivoService {
     }
 
     public List<ArquivoResponseDTO> listar(UUID profissionalId, UUID pacienteId, Long tipoId) {
+        if (!pacienteService.existeRelacao(pacienteId, profissionalId)) {
+            throw new RelacaoInvalidException("Não foi possível listar arquivos para esse paciente.");
+        }
+
         List<Arquivo> arquivos = repository.findByProfissionalIdAndPacienteIdAndTipoId(
                 profissionalId, pacienteId, tipoId
         );
@@ -104,6 +110,10 @@ public class ArquivoService {
     }
 
     public List<ArquivoResponseDTO> buscarPorData(UUID profissionalId, UUID pacienteId, Long tipoId, LocalDate data) {
+        if (!pacienteService.existeRelacao(pacienteId, profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem vinculo com este paciente para buscar arquivos por data.");
+        }
+
         List<Arquivo> arquivos = repository.findByProfissionalIdAndPacienteIdAndDataAndTipoId(
                 profissionalId, pacienteId, data, tipoId
         );
@@ -116,12 +126,12 @@ public class ArquivoService {
                 }).collect(Collectors.toList());
     }
 
-    public void deletar(String objectName) {
-        if (!repository.existsById(objectName)) {
-            throw new ArquivoNotFoundException("O arquivo selecionado não existe ou já foi apagado.");
-        }
+    public void deletar(String objectName, UUID profissionalId) {
 
-        repository.deleteById(objectName);
+        Arquivo arquivo = repository.findByObjectNameAndProfissionalId(objectName, profissionalId)
+                .orElseThrow(() -> new ArquivoNotFoundException("O arquivo selecionado nao existe ou nao pertence ao profissional autenticado."));
+
+        repository.delete(arquivo);
         storageService.deletarArquivo(objectName);
     }
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/ArquivoService.java
@@ -131,6 +131,10 @@ public class ArquivoService {
         Arquivo arquivo = repository.findByObjectNameAndProfissionalId(objectName, profissionalId)
                 .orElseThrow(() -> new ArquivoNotFoundException("O arquivo selecionado nao existe ou nao pertence ao profissional autenticado."));
 
+        if (!pacienteService.existeRelacao(arquivo.getPacienteId(), profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem vinculo com este paciente para excluir arquivos.");
+        }
+
         repository.delete(arquivo);
         storageService.deletarArquivo(objectName);
     }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AtendimentoService.java
@@ -13,7 +13,6 @@ import br.org.apae.atendimento.dtos.response.AtendimentoResponseDTO;
 import br.org.apae.atendimento.dtos.response.MesAnoAtendimentoResponseDTO;
 import br.org.apae.atendimento.entities.Agendamento;
 import br.org.apae.atendimento.entities.Atendimento;
-import br.org.apae.atendimento.entities.ProfissionalSaude;
 import br.org.apae.atendimento.entities.Topico;
 import br.org.apae.atendimento.exceptions.invalid.TopicoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.AgendamentoNotFoundException;
@@ -22,27 +21,23 @@ import br.org.apae.atendimento.exceptions.invalid.RelacaoInvalidException;
 import br.org.apae.atendimento.exceptions.notfound.AtendimentoNotFoundException;
 import br.org.apae.atendimento.mappers.AtendimentoMapper;
 import br.org.apae.atendimento.repositories.AtendimentoRepository;
-import br.org.apae.atendimento.repositories.ProfissionalSaudeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AtendimentoService {
     private final AtendimentoRepository repository;
-    private final ProfissionalSaudeRepository profissionalRepository;
     private final AgendamentoService agendamentoService;
     private final AtendimentoMapper atendimentoMapper;
     private final PacienteService pacienteService;
 
     public AtendimentoService(AtendimentoRepository repository,
-                              ProfissionalSaudeRepository profissionalRepository,
                               AgendamentoService agendamentoService,
                               AtendimentoMapper atendimentoMapper,
                               PacienteService pacienteService
                               ) {
 
         this.repository = repository;
-        this.profissionalRepository = profissionalRepository;
         this.agendamentoService = agendamentoService;
         this.atendimentoMapper = atendimentoMapper;
         this.pacienteService = pacienteService;
@@ -61,8 +56,7 @@ public class AtendimentoService {
         }
 
         Atendimento dadosConvertidos = atendimentoMapper.toEntityPadrao(atendimentoRequestDTO);
-        ProfissionalSaude profissional = profissionalRepository.getReferenceById(profissionalId);
-        dadosConvertidos.setProfissional(profissional);
+        dadosConvertidos.setProfissionalId(profissionalId);
 
         verificarRelatorio(atendimentoRequestDTO.relatorio());
 
@@ -70,7 +64,12 @@ public class AtendimentoService {
 
         Atendimento dadosPersistidos = repository.save(dadosConvertidos);
         try {
-            tratarAgendamento(atendimentoRequestDTO.pacienteId(), atendimentoRequestDTO.data(), dadosPersistidos.getNumeracao());
+            tratarAgendamento(
+                    profissionalId,
+                    atendimentoRequestDTO.pacienteId(),
+                    atendimentoRequestDTO.data(),
+                    dadosPersistidos.getNumeracao()
+            );
         } catch (AgendamentoNotFoundException e) {
         }
 
@@ -89,14 +88,21 @@ public class AtendimentoService {
         }
     }
 
-    public void tratarAgendamento(UUID pacienteId, LocalDate data, String numeracao) {
-        Agendamento agendamento = agendamentoService.buscarAgendamentoPorDataEPaciente(data, pacienteId);
-        agendamento.setNumeracao(numeracao);
+    public void tratarAgendamento(UUID profissionalId, UUID pacienteId, LocalDate data, String numeracao) {
+        Agendamento agendamento = agendamentoService.buscarAgendamentoPorDataProfissionalEPaciente(
+                data,
+                profissionalId,
+                pacienteId
+        );
 
+        agendamento.setNumeracao(numeracao);
         agendamentoService.setStatus(agendamento);
     }
 
     public List<MesAnoAtendimentoResponseDTO> getAtendimentosAgrupadosPorMes(UUID pacienteId, UUID profissionalId) {
+        if (!pacienteService.existeRelacao(pacienteId, profissionalId)) {
+            throw new RelacaoInvalidException("Você não tem permissão para listar atendimentos deste paciente.");
+        }
 
         List<Atendimento> atendimentos = repository
                 .findByPacienteIdAndProfissionalIdComRelatorio(pacienteId, profissionalId);
@@ -115,7 +121,11 @@ public class AtendimentoService {
             throw new RelacaoInvalidException("Você não tem permissão para excluir atendimentos deste paciente.");
         }
 
-        repository.deleteById(atendimentoId);
+        Atendimento atendimento = repository
+                .findByIdAndProfissionalIdAndPacienteId(atendimentoId, profissionalId, pacienteId)
+                .orElseThrow(() -> new AtendimentoNotFoundException("O atendimento não foi encontrado."));
+
+        repository.delete(atendimento);
     }
 
     public String gerarProximaNumeracao(UUID profissionalId, LocalDate data) {
@@ -131,12 +141,17 @@ public class AtendimentoService {
 
     @Transactional(readOnly = false)
     public AtendimentoResponseDTO editar(AtendimentoRequestDTO requestDTO, UUID atendimentoId, UUID profissionalId) {
-        if (!pacienteService.existeRelacao(requestDTO.pacienteId(), profissionalId)) {
-            throw new RelacaoInvalidException("Você não tem permissão para editar atendimentos deste paciente.");
-        }
-
         Atendimento atendimento = repository.findByIdComRelatorio(atendimentoId)
                 .orElseThrow(() -> new AtendimentoNotFoundException("O atendimento que deseja editar não foi encontrado."));
+
+        if (!pacienteService.existeRelacao(requestDTO.pacienteId(), profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem permissao para editar atendimentos deste paciente.");
+        }
+
+        if (!atendimento.getProfissionalId().equals(profissionalId)) {
+            throw new RelacaoInvalidException("Voce nao tem permissao para editar este atendimento.");
+        }
+
         verificarRelatorio(requestDTO.relatorio());
 
         atendimento.getRelatorio().clear();
@@ -153,14 +168,17 @@ public class AtendimentoService {
             atendimento.setDataAtendimento(LocalDateTime.of(requestDTO.data(), requestDTO.hora()));
         }
 
+        atendimento.setPacienteId(requestDTO.pacienteId());
+
         return atendimentoMapper.toDTOPadrao(repository.save(atendimento));
     }
 
     @Transactional
     public void concluirAtendimento(UUID profissionalId, UUID atendimentoId) {
-        if (!repository.existsById(atendimentoId)) {
-            throw new AtendimentoNotFoundException("O atendimento não existe.");
+        int atualizados = repository.concluirAtendimento(atendimentoId, profissionalId);
+
+        if (atualizados == 0) {
+            throw new AtendimentoNotFoundException("O atendimento nao existe ou nao pertence ao profissional autenticado.");
         }
-        repository.concluirAtendimento(atendimentoId);
     }
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/PacienteService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/PacienteService.java
@@ -42,11 +42,6 @@ public class PacienteService {
         return pacienteMapper.toDTOPadrao(paciente);
     }
 
-    public Paciente getPacienteById(UUID id) {
-        return repository
-                .findById(id).orElseThrow(() -> new PacienteNotFoundException("Paciente não encontrado no sistema."));
-    }
-
     public boolean existeRelacao(UUID pacienteId, UUID profissionalId) {
         return repository.existeRelacao(pacienteId, profissionalId);
     }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/PacienteService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/PacienteService.java
@@ -35,9 +35,11 @@ public class PacienteService {
         this.storageService = storageService;
     }
 
-    public PacienteResponseDTO getPaciente(UUID id) {
-        Paciente paciente = getPacienteById(id);
-        return this.pacienteMapper.toDTOPadrao(paciente);
+    public PacienteResponseDTO getPaciente(UUID id, UUID profissionalId) {
+        Paciente paciente = repository.findByIdAndProfissionalId(id, profissionalId)
+                .orElseThrow(() -> new PacienteNotFoundException("Paciente nao encontrado para o profissional autenticado."));
+
+        return pacienteMapper.toDTOPadrao(paciente);
     }
 
     public Paciente getPacienteById(UUID id) {
@@ -49,11 +51,16 @@ public class PacienteService {
         return repository.existeRelacao(pacienteId, profissionalId);
     }
 
-    public String getNomeCompletoPacienteById(UUID id) {
-        String nome = repository.findNomeCompletoById(id);
-        if (nome == null) {
-            throw new PacienteNotFoundException("Não foi possível localizar o nome do paciente.");
+    public String getNomeCompletoPacienteById(UUID id, UUID profissionalId) {
+        if (!existeRelacao(id, profissionalId)) {
+            throw new PacienteNotFoundException("Paciente nao encontrado para o profissional autenticado.");
         }
+
+        String nome = repository.findNomeCompletoByIdAndProfissionalId(id, profissionalId);
+        if (nome == null) {
+            throw new PacienteNotFoundException("Nao foi possivel localizar o nome do paciente.");
+        }
+
         return nome;
     }
 
@@ -80,16 +87,16 @@ public class PacienteService {
         return new PaginatedResponseDTO<>(data, meta);
     }
 
-    public String adicionarFoto(MultipartFile file, UUID pacienteId){
-
-        if (!repository.existsById(pacienteId)) {
-            throw new PacienteNotFoundException("Não é possivel adicionar foto. Paciente não encontrado.");
+    public String adicionarFoto(MultipartFile file, UUID pacienteId, UUID profissionalId) {
+        if (!existeRelacao(pacienteId, profissionalId)) {
+            throw new PacienteNotFoundException("Paciente nao encontrado para o profissional autenticado.");
         }
-       return storageService.uploadArquivo(FOTO_PATH + pacienteId, file);
+
+        return storageService.uploadArquivo(FOTO_PATH + pacienteId, file);
     }
 
     @Transactional(readOnly = true)
-    public List<PacienteDropdownResponseDTO> listarParaDropdown() {
-        return repository.listarParaDropdown();
+    public List<PacienteDropdownResponseDTO> listarParaDropdown(UUID profissionalId) {
+        return repository.listarParaDropdown(profissionalId);
     }
 }

--- a/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceTest.java
+++ b/backend/atendimento/src/test/java/br/org/apae/atendimento/services/AtendimentoServiceTest.java
@@ -86,7 +86,7 @@ class AtendimentoServiceTest {
         when(repository.save(any())).thenReturn(entity);
         when(atendimentoMapper.toDTOPadrao(entity)).thenReturn(mock(AtendimentoResponseDTO.class));
 
-        when(agendamentoService.buscarAgendamentoPorDataEPaciente(any(), any()))
+        when(agendamentoService.buscarAgendamentoPorDataProfissionalEPaciente(any(), any(), any()))
                 .thenReturn(new Agendamento());
 
         AtendimentoResponseDTO response = service.addAtendimento(requestDTO, profissionalId);
@@ -203,7 +203,7 @@ class AtendimentoServiceTest {
 
         doThrow(new AgendamentoNotFoundException("nao encontrado"))
                 .when(agendamentoService)
-                .buscarAgendamentoPorDataEPaciente(any(), any());
+                .buscarAgendamentoPorDataProfissionalEPaciente(any(), any(), any());
 
         assertDoesNotThrow(() -> service.addAtendimento(requestDTO, profissionalId));
     }
@@ -221,7 +221,7 @@ class AtendimentoServiceTest {
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(atendimentoMapper.toDTOPadrao(any())).thenReturn(mock(AtendimentoResponseDTO.class));
 
-        when(agendamentoService.buscarAgendamentoPorDataEPaciente(any(), any()))
+        when(agendamentoService.buscarAgendamentoPorDataProfissionalEPaciente(any(), any(), any()))
                 .thenReturn(new Agendamento());
 
         service.addAtendimento(requestDTO, profissionalId);


### PR DESCRIPTION
## Resumo

Refatora a camada de atendimento para tratar `Paciente` e `ProfissionalSaude` como dados externos somente leitura, consultados via views imutáveis, e mantém as gravações restritas às tabelas próprias do schema `atendimento`.

Também remove resíduos do acoplamento com Firebase e mantém a autenticação atual baseada em login/senha com JWT.

## Principais alterações

- Ajusta entidades, mappers e services para gravar `paciente_id` e `profissional_id` como FKs escalares nas tabelas de atendimento.
- Remove dependência de escrita em entidades imutáveis nos fluxos de atendimento, agendamento e arquivos.
- Atualiza consultas de pacientes para usar `atendimento.vw_pacientes` e `atendimento.profissional_paciente`.
- Valida vínculo paciente/profissional antes de criar, editar, listar ou excluir atendimentos, agendamentos e anexos.
- Ajusta endpoints de paciente para respeitarem o profissional autenticado.
- Remove referências/resíduos de Firebase no código, configuração e dependências.
- Padroniza `numeracao` como `String`, compatível com `VARCHAR(50)` nas migrations.
- Atualiza testes afetados pela mudança na busca de agendamento por paciente/profissional/data.

## Validação

- Compilação de testes ajustada após renomear `buscarAgendamentoPorDataEPaciente` para `buscarAgendamentoPorDataProfissionalEPaciente`.
- Varredura feita para garantir ausência de:
  - `Firebase`
  - `firebaseUID`
  - `firebase.json`
  - `FIREBASE_SERVICE_ACCOUNT_JSON`
  - `setPaciente(...)`
  - `setProfissional(...)`
  - `getReferenceById(...)`
  - `primeiroNome`
  - `numeroAtendimento`