### PR TITLE
[Feat] integração dos agendamentos do sistema geral com os agendamentos do sistema de atendimento

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,68 @@ pnpm install
 pnpm dev
 ```
 
+# Integração com o Sistema Geral (apae-geral)
+
+A agenda do Sistema de Atendimento pode exibir, junto com os agendamentos locais, os **agendamentos gerados no Sistema Geral da APAE** (projeto `apae-geral`). A integração é feita pelo backend de atendimento, que se autentica no apae-geral e consulta os agendamentos do profissional logado.
+
+> **Componente responsável:** `backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java`
+
+### Como funciona o fluxo
+1. Ao listar a agenda (`GET /agendamento`), o backend de atendimento busca os agendamentos **locais** no seu próprio banco.
+2. Em seguida, autentica no apae-geral (`POST /apae-geral/api/auth/signin`) e consulta os **agendamentos gerados** do profissional (`GET /apae-geral/api/appointments/professional/{profissionalId}/generated`).
+3. As duas listas são mescladas e retornadas. Os itens externos vêm com a flag `externo: true`.
+
+### Pré-requisitos
+- O projeto **apae-geral** clonado e rodando localmente (backend + banco PostgreSQL + MinIO).
+- O backend do apae-geral acessível em `http://localhost:8090/apae-geral`.
+
+> ⚠️ **Atenção ao caminho:** o apae-geral usa `spring.mvc.servlet.path: /api`, então **todos os endpoints REST ficam sob `/apae-geral/api/...`** (e não `/apae-geral/...`). Chamar o caminho sem o `/api` resulta em **HTTP 403** (a requisição cai na página de erro, que é protegida).
+
+### Passo a passo
+
+**1. Suba o apae-geral**
+
+No diretório do projeto apae-geral (ex.: `../APAE/apps/api`), com o `.env` preenchido (`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, `MINIO_*`, `API_PORT=8090`):
+```bash
+cd apps/api
+./mvnw spring-boot:run
+```
+Valide que subiu:
+```bash
+curl -X POST http://localhost:8090/apae-geral/api/auth/signin \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin@teste.com","password":"senha123"}'
+# Deve retornar 200 com {"token":"..."}
+```
+
+**2. Configure as credenciais/URL da integração (opcional)**
+
+Por padrão o cliente já aponta para `http://localhost:8090/apae-geral/api` e usa o usuário `admin@teste.com` / `senha123`. Para sobrescrever sem recompilar, adicione ao `backend/docker/docker-compose.properties`:
+```properties
+api.geral.url=http://localhost:8090/apae-geral/api
+api.geral.username=admin@teste.com
+api.geral.password=senha123
+```
+> Garanta que esse usuário existe no banco do apae-geral e que a senha confere (a senha é validada via BCrypt).
+
+**3. Alinhe o ID do profissional entre os dois sistemas**
+
+A integração busca a agenda usando o **ID do profissional logado** no atendimento. Para que os agendamentos externos apareçam, esse ID precisa ser **o mesmo** de um profissional que tenha agenda no apae-geral. Ou seja: o registro em `vw_profissionais` (atendimento) deve ter o mesmo `id` do profissional correspondente em `profissionais_da_saude` (apae-geral).
+
+**4. Suba o backend de atendimento e faça login**
+
+```bash
+cd backend/atendimento
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
+```
+Faça login no frontend com um profissional cujo ID esteja alinhado (passo 3) e abra a **Agenda**. Os agendamentos do sistema geral devem aparecer junto com os locais.
+
+### Solução de problemas
+- **Nada aparece / lista só com os locais:** confira o log do backend de atendimento. O `AgendamentoExternoClient` registra avisos (`log.warn`) com a causa — token nulo, 403, 401 etc.
+- **`Erro ao obter token do sistema geral: 403`:** a URL está sem o `/api` ou o apae-geral não está no ar.
+- **`401 - E-mail ou senha incorretos`:** o usuário/senha da integração não confere com o banco do apae-geral.
+- **Login OK mas lista vazia:** o ID do profissional logado não corresponde a nenhum profissional com agenda no apae-geral (ver passo 3).
+
 # Contribuições
 
 **1. Clone o repositório**

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/dtos/response/AgendamentoResponseDTO.java
@@ -11,5 +11,7 @@ public record AgendamentoResponseDTO(
         LocalDate data,
         LocalTime time,
         Long numeroAtendimento,
-        boolean status) {
+        boolean status,
+        boolean externo
+) {
 }

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/mappers/AgendamentoMapper.java
@@ -32,7 +32,8 @@ public class AgendamentoMapper extends AbstractMapper<Agendamento, AgendamentoRe
                 entidadePadrao.getDataHora().toLocalDate(),
                 entidadePadrao.getDataHora().toLocalTime(),
                 entidadePadrao.getNumeracao(),
-                entidadePadrao.isStatus()
+                entidadePadrao.isStatus(),
+                false
         );
     }
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
@@ -92,10 +92,12 @@ public class AgendamentoService {
                 .map(agendamentoMapper::toDTOPadrao)
                 .toList();
 
-        List<AgendamentoResponseDTO> externos = agendamentoExternoClient.buscarAgendamentos(profissionalId);
+        List<AgendamentoResponseDTO> externos = agendamentoExternoClient.buscarAgendamentosPorDataHora(profissionalId);
 
         List<AgendamentoResponseDTO> todosAgendamentos = new ArrayList<>(locais);
         todosAgendamentos.addAll(externos);
+        todosAgendamentos.sort(Comparator.comparing(AgendamentoResponseDTO::data)
+                .thenComparing(AgendamentoResponseDTO::time));
 
         return todosAgendamentos.stream()
                 .collect(Collectors.groupingBy(

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/AgendamentoService.java
@@ -12,12 +12,15 @@ import br.org.apae.atendimento.exceptions.invalid.RelacaoInvalidException;
 import br.org.apae.atendimento.mappers.AgendamentoMapper;
 import br.org.apae.atendimento.repositories.AgendamentoRepository;
 import br.org.apae.atendimento.repositories.AtendimentoRepository;
+import br.org.apae.atendimento.services.integration.AgendamentoExternoClient;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,18 +33,21 @@ public class AgendamentoService {
     private ProfissionalSaudeService profissionalSaudeService;
     private AgendamentoMapper agendamentoMapper;
     private AtendimentoRepository atendimentoRepository;
+    private AgendamentoExternoClient agendamentoExternoClient;
 
     public AgendamentoService(AgendamentoRepository repository,
                               PacienteService pacienteService,
                               ProfissionalSaudeService profissionalSaudeService,
                               AgendamentoMapper agendamentoMapper,
-                              AtendimentoRepository atendimentoRepository) {
+                              AtendimentoRepository atendimentoRepository,
+                              AgendamentoExternoClient agendamentoExternoClient) { 
 
         this.repository = repository;
         this.pacienteService = pacienteService;
         this.profissionalSaudeService = profissionalSaudeService;
         this.agendamentoMapper = agendamentoMapper;
         this.atendimentoRepository = atendimentoRepository;
+        this.agendamentoExternoClient = agendamentoExternoClient; 
     }
 
     public Agendamento save(Agendamento agendamento) {
@@ -81,15 +87,29 @@ public class AgendamentoService {
 
     @Transactional
     public List<DiaAgendamentoResponseDTO> listarAgrupadoPorDia(UUID profissionalId) {
-        return repository.findByProfissionalIdOrderByDataHora(profissionalId)
+        List<AgendamentoResponseDTO> locais = repository.findByProfissionalIdOrderByDataHora(profissionalId)
                 .stream()
+                .map(agendamentoMapper::toDTOPadrao)
+                .toList();
+
+        List<AgendamentoResponseDTO> externos = agendamentoExternoClient.buscarAgendamentos(profissionalId);
+
+        List<AgendamentoResponseDTO> todosAgendamentos = new ArrayList<>(locais);
+        todosAgendamentos.addAll(externos);
+
+        return todosAgendamentos.stream()
                 .collect(Collectors.groupingBy(
-                        a -> a.getDataHora().toLocalDate(),
-                        Collectors.mapping(agendamentoMapper::toDTOPadrao, Collectors.toList())
+                        AgendamentoResponseDTO::data,
+                        Collectors.toList()
                 ))
                 .entrySet().stream()
                 .sorted(Map.Entry.<LocalDate, List<AgendamentoResponseDTO>>comparingByKey().reversed())
-                .map(e -> new DiaAgendamentoResponseDTO(e.getKey(), e.getValue()))
+                .map(e -> {
+                    List<AgendamentoResponseDTO> ordenadosPorHora = e.getValue().stream()
+                            .sorted(Comparator.comparing(AgendamentoResponseDTO::time))
+                            .toList();
+                    return new DiaAgendamentoResponseDTO(e.getKey(), ordenadosPorHora);
+                })
                 .toList();
     }
 

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
@@ -1,0 +1,135 @@
+package br.org.apae.atendimento.services.integration;
+
+import br.org.apae.atendimento.dtos.response.AgendamentoResponseDTO;
+import br.org.apae.atendimento.services.PacienteService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class AgendamentoExternoClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AgendamentoExternoClient.class);
+
+    private final RestTemplate restTemplate;
+    private final PacienteService pacienteService;
+
+    @Value("${api.geral.url:http://localhost:8090/apae-geral/api}")
+    private String apiGeralUrl;
+
+    @Value("${api.geral.username:admin@teste.com}")
+    private String apiGeralUsername;
+
+    @Value("${api.geral.password:senha123}")
+    private String apiGeralPassword;
+
+    public AgendamentoExternoClient(PacienteService pacienteService) {
+        this.restTemplate = new RestTemplate();
+        this.pacienteService = pacienteService;
+    }
+
+    private String obterTokenSistemaGeral() {
+        try {
+            String loginUrl = apiGeralUrl + "/auth/signin";
+            Map<String, String> credenciais = new HashMap<>();
+            credenciais.put("username", apiGeralUsername);
+            credenciais.put("password", apiGeralPassword);
+
+            ResponseEntity<Map> response = restTemplate.postForEntity(loginUrl, credenciais, Map.class);
+            if (response.getBody() == null) {
+                log.warn("Login no sistema geral retornou corpo vazio (url={})", loginUrl);
+                return null;
+            }
+            return (String) response.getBody().get("token");
+        } catch (Exception e) {
+            log.warn("Erro ao obter token do sistema geral: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public List<AgendamentoResponseDTO> buscarAgendamentos(UUID profissionalId) {
+        String token = obterTokenSistemaGeral();
+        if (token == null) return new ArrayList<>();
+
+        try {
+            String url = apiGeralUrl + "/appointments/professional/" + profissionalId + "/generated";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(token);
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            if (response.getBody() == null) return new ArrayList<>();
+
+            return response.getBody().stream()
+                    .filter(map -> !Boolean.TRUE.equals(map.get("cancelled")))
+                    .map(this::mapearParaLocalDTO)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+        } catch (Exception e) {
+            log.warn("Erro ao buscar agendamentos externos para profissional {}: {}", profissionalId, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    private AgendamentoResponseDTO mapearParaLocalDTO(Map<String, Object> externalData) {
+        try {
+            String effectiveDateTime = (String) externalData.get("effectiveDateTime");
+            if (effectiveDateTime == null || !effectiveDateTime.contains("T")) {
+                log.warn("Agendamento externo {} ignorado: effectiveDateTime ausente ou inválido",
+                        externalData.get("id"));
+                return null;
+            }
+            String[] partes = effectiveDateTime.split("T");
+            LocalDate data = LocalDate.parse(partes[0]);
+            LocalTime hora = LocalTime.parse(partes[1]);
+
+            Object patientIdRaw = externalData.get("patientId");
+            if (patientIdRaw == null) {
+                log.warn("Agendamento externo {} ignorado: patientId ausente", externalData.get("id"));
+                return null;
+            }
+            UUID patientId = UUID.fromString((String) patientIdRaw);
+
+            String nomePaciente = "Paciente (Sistema Geral)";
+            try {
+                nomePaciente = pacienteService.getNomeCompletoPacienteById(patientId);
+            } catch (Exception ignored) {
+                // paciente pode não existir localmente; mantém o rótulo padrão
+            }
+
+            return new AgendamentoResponseDTO(
+                    UUID.fromString((String) externalData.get("id")),
+                    patientId,
+                    nomePaciente,
+                    data,
+                    hora,
+                    0L,
+                    Boolean.TRUE.equals(externalData.get("performed")),
+                    true
+            );
+        } catch (Exception e) {
+            log.warn("Erro ao mapear agendamento externo {}: {}", externalData.get("id"), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
@@ -59,7 +59,7 @@ public class AgendamentoExternoClient {
         }
     }
 
-    public List<AgendamentoResponseDTO> buscarAgendamentos(UUID profissionalId) {
+    public List<AgendamentoResponseDTO> buscarAgendamentosPorDataHora(UUID profissionalId) {
         String token = obterTokenSistemaGeral();
         if (token == null) return new ArrayList<>();
 
@@ -83,6 +83,8 @@ public class AgendamentoExternoClient {
                     .filter(map -> !Boolean.TRUE.equals(map.get("cancelled")))
                     .map(this::mapearParaLocalDTO)
                     .filter(Objects::nonNull)
+                    .sorted(Comparator.comparing(AgendamentoResponseDTO::data)
+                            .thenComparing(AgendamentoResponseDTO::time))
                     .collect(Collectors.toList());
 
         } catch (Exception e) {

--- a/frontend/atendimento-app/src/features/agenda/components/agendamentoCard.tsx
+++ b/frontend/atendimento-app/src/features/agenda/components/agendamentoCard.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Check } from "lucide-react";
+import { Trash2, Check, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface AgendamentoCardProps {
@@ -6,6 +6,8 @@ interface AgendamentoCardProps {
   paciente: string;
   horario: string;
   numeroAtendimento: number;
+  status: boolean;
+  externo: boolean; 
   onDeleteClick?: () => void;
 }
 
@@ -14,29 +16,45 @@ export default function AgendamentoCard({
   paciente,
   horario,
   numeroAtendimento,
+  status,
+  externo,
   onDeleteClick,
 }: AgendamentoCardProps) {
 
   return (
     <>
-      <div className="bg-white border border-[#E5E7EB] rounded-2xl shadow-sm p-4 flex flex-col justify-between min-h-62.5">
+      <div className={`bg-white border ${externo ? 'border-amber-200' : 'border-[#E5E7EB]'} rounded-2xl shadow-sm p-4 flex flex-col justify-between min-h-62.5`}>
         <div className="flex justify-between items-start gap-2">
-          <div className="text-[17px] font-semibold text-[#344054] leading-tight line-clamp-2">
-            {paciente}
+          <div className="flex flex-col gap-1">
+            <div className="text-[17px] font-semibold text-[#344054] leading-tight line-clamp-2">
+              {paciente}
+            </div>
+            {/* Tag visual para o agendamento do Sistema Geral */}
+            {externo && (
+              <span className="text-[10px] bg-amber-50 text-amber-600 px-2 py-0.5 rounded w-fit border border-amber-100 flex items-center gap-1">
+                <Lock size={10} /> Sistema Geral
+              </span>
+            )}
           </div>
 
           <div className="flex items-center gap-2">
-            <span className="text-[11px] font-semibold text-white bg-[#165BAA] w-6 h-6 flex items-center justify-center rounded-full">
-              {String(numeroAtendimento).padStart(2, "0")}
-            </span>
+            {/* Oculta a numeração se for um agendamento externo */}
+            {!externo && (
+              <span className="text-[11px] font-semibold text-white bg-[#165BAA] w-6 h-6 flex items-center justify-center rounded-full">
+                {String(numeroAtendimento).padStart(2, "0")}
+              </span>
+            )}
 
-            <button
-              onClick={onDeleteClick}
-              className="text-red-400 hover:text-red-600 cursor-pointer"
-              title="Apagar agendamento"
-            >
-              <Trash2 size={20} />
-            </button>
+            {/* Oculta a lixeira se for um agendamento externo */}
+            {!externo && (
+              <button
+                onClick={onDeleteClick}
+                className="text-red-400 hover:text-red-600 cursor-pointer"
+                title="Apagar agendamento"
+              >
+                <Trash2 size={20} />
+              </button>
+            )}
           </div>
         </div>
 
@@ -44,6 +62,25 @@ export default function AgendamentoCard({
           <div className="bg-[#F8FAFD] w-full min-h-27.5 flex justify-center items-center">
             <span className="text-3xl font-bold text-[#344054]">{horario}</span>
           </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            className={`h-8 px-3 rounded-full text-xs shadow-sm ${
+              status
+                ? "bg-green-500 hover:bg-green-600 text-white"
+                : "bg-white border border-[#3B82F6] hover:bg-[#F8FAFD] text-[#344054]"
+            }`}
+          >
+            {status ? (
+              <>
+                <Check size={14} className="mr-1" />
+                Concluído
+              </>
+            ) : (
+              <>Não concluído</>
+            )}
+          </Button>
         </div>
       </div>
     </>

--- a/frontend/atendimento-app/src/features/agenda/components/agendamentoPage.tsx
+++ b/frontend/atendimento-app/src/features/agenda/components/agendamentoPage.tsx
@@ -46,7 +46,8 @@ export default function AgendamentoPage() {
 
   const agendamentosFiltrados = useMemo(() => {
     if (!dataSelecionada) return agendamentos;
-    return agendamentos.filter((a) => a.data === dataSelecionada);
+    const dataBR = isoParaBR(dataSelecionada); 
+    return agendamentos.filter((a) => a.data === dataBR);
   }, [agendamentos, dataSelecionada]);
 
   const gruposParaRenderizar = useMemo(
@@ -162,6 +163,8 @@ export default function AgendamentoPage() {
                   paciente={item.paciente}
                   horario={item.horario}
                   numeroAtendimento={item.numeracao}
+                  status={item.status} 
+                  externo={item.externo} 
                   onDeleteClick={() => {
                     setAgendamentoSelecionado(item);
                     setOpenDelete(true);

--- a/frontend/atendimento-app/src/features/agenda/types.ts
+++ b/frontend/atendimento-app/src/features/agenda/types.ts
@@ -8,6 +8,7 @@ export interface Agendamento {
   horario: string;
   numeracao: number;
   status: boolean;
+  externo: boolean;
 }
 
 export interface AgendamentoResponse {
@@ -20,6 +21,7 @@ export interface AgendamentoResponse {
   time: string;
   numeroAtendimento: number;
   status: boolean;
+  externo?: boolean;
 }
 
 export interface DiaAgendamento {

--- a/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
+++ b/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
@@ -14,10 +14,11 @@ export function normalizarAgendamentos(
         paciente: a.nomePaciente,
         profissionalId: a.profissionalId || "",
         nomeProfissional: a.nomeProfissional || "Não informado",
-        horario: a.time,
+        horario: a.time.substring(0, 5), 
         data: isoParaBR(a.data),
         numeracao: a.numeroAtendimento ?? 0,
         status: a.status,
+        externo: a.externo ?? false, 
       });
     });
   });


### PR DESCRIPTION
## Objetivo
  Exibir, na agenda do Sistema de Atendimento, os agendamentos gerados no Sistema Geral da APAE (apae-geral) junto com os agendamentos
  locais. 

# Tarefas relacionadas:
#318 
https://github.com/IFPBEsp/APAE/pull/865


  ## O que foi feito

  ### Backend
  - Novo `AgendamentoExternoClient` (services/integration/): autentica no apae-geral e busca os agendamentos gerados do profissional.
    - Login em `POST /apae-geral/api/auth/signin` e consulta em `GET /apae-geral/api/appointments/professional/{id}/generated` (endpoints
  sob `/api` por causa do `spring.mvc.servlet.path`).
    - Robustez: item externo inválido é ignorado sem derrubar a lista; `cancelled`/`performed` null-safe.
    - Logging via SLF4J no lugar de `System.err`.
  - `AgendamentoService.listarAgrupadoPorDia`: mescla agendamentos locais + externos.
  - `AgendamentoResponseDTO` / `AgendamentoMapper`: nova flag `externo`.

  ### Frontend
  - Ajustes na feature de agenda (agendamentoCard, agendamentoPage, types, normalizarAgendamento) para exibir os agendamentos externos.

  ### Documentação
  - Seção "Integração com o Sistema Geral (apae-geral)" no README.md da raiz, com passo a passo e troubleshooting.

  ## Como testar
  1. Suba o apae-geral em http://localhost:8090/apae-geral.
  2. Garanta um usuário de integração válido no apae-geral.
  3. Faça login no atendimento como um profissional cujo id corresponda a um profissional com agenda no apae-geral.
  4. Abra a Agenda — os agendamentos externos aparecem com a flag `externo`. 
  
  
  ## Evidencias 

<img width="2860" height="1390" alt="image" src="https://github.com/user-attachments/assets/323bf88f-d38e-4dbc-83ab-3eaf00c5bb6e" />



