### PR TITLE
fix: corrige listagem e ordenação dos agendamentos integrados

### DIFF
--- a/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
+++ b/backend/atendimento/src/main/java/br/org/apae/atendimento/services/integration/AgendamentoExternoClient.java
@@ -81,7 +81,7 @@ public class AgendamentoExternoClient {
 
             return response.getBody().stream()
                     .filter(map -> !Boolean.TRUE.equals(map.get("cancelled")))
-                    .map(this::mapearParaLocalDTO)
+                    .map(map -> mapearParaLocalDTO(map, profissionalId))
                     .filter(Objects::nonNull)
                     .sorted(Comparator.comparing(AgendamentoResponseDTO::data)
                             .thenComparing(AgendamentoResponseDTO::hora))
@@ -93,7 +93,7 @@ public class AgendamentoExternoClient {
         }
     }
 
-    private AgendamentoResponseDTO mapearParaLocalDTO(Map<String, Object> externalData) {
+    private AgendamentoResponseDTO mapearParaLocalDTO(Map<String, Object> externalData, UUID profissionalId) {
         try {
             String effectiveDateTime = (String) externalData.get("effectiveDateTime");
             if (effectiveDateTime == null || !effectiveDateTime.contains("T")) {
@@ -114,7 +114,7 @@ public class AgendamentoExternoClient {
 
             String nomePaciente = "Paciente (Sistema Geral)";
             try {
-                nomePaciente = pacienteService.getNomeCompletoPacienteById(patientId);
+                nomePaciente = pacienteService.getNomeCompletoPacienteById(patientId, profissionalId);
             } catch (Exception ignored) {
                 // paciente pode não existir localmente; mantém o rótulo padrão
             }

--- a/frontend/atendimento-app/src/features/agenda/components/agendamentoCard.tsx
+++ b/frontend/atendimento-app/src/features/agenda/components/agendamentoCard.tsx
@@ -5,7 +5,7 @@ interface AgendamentoCardProps {
   id: string;
   paciente: string;
   horario: string;
-  numeroAtendimento: number;
+  numeroAtendimento: string;
   status: boolean;
   externo: boolean; 
   onDeleteClick?: () => void;
@@ -15,7 +15,7 @@ export default function AgendamentoCard({
   id,
   paciente,
   horario,
-  numeroAtendimento,
+  numeracao,
   status,
   externo,
   onDeleteClick,
@@ -41,7 +41,7 @@ export default function AgendamentoCard({
             {/* Oculta a numeração se for um agendamento externo */}
             {!externo && (
               <span className="text-[11px] font-semibold text-white bg-[#165BAA] w-6 h-6 flex items-center justify-center rounded-full">
-                {String(numeroAtendimento).padStart(2, "0")}
+                {String(numeracao ?? "0").padStart(2, "0")}
               </span>
             )}
 

--- a/frontend/atendimento-app/src/features/agenda/types.ts
+++ b/frontend/atendimento-app/src/features/agenda/types.ts
@@ -12,20 +12,20 @@ export interface Agendamento {
 }
 
 export interface AgendamentoResponse {
-  atendimentoId: string;
+  id: string;
   pacienteId: string;
   nomePaciente: string;
-  profissionalId: string;
-  nomeProfissional: string;
+  profissionalId?: string;
+  nomeProfissional?: string;
   data: string;
-  time: string;
-  numeroAtendimento: string;
+  hora: string;
+  numeracao: string;
   status: boolean;
   externo?: boolean;
 }
 
 export interface DiaAgendamento {
-  data: string;
+  dia: string;
   agendamentos: AgendamentoResponse[];
 }
 

--- a/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
+++ b/frontend/atendimento-app/src/features/agenda/utils/normalizarAgendamento.ts
@@ -1,27 +1,58 @@
-import { isoParaBR } from "@/utils/formatarData";
-import { Agendamento, AgendamentoResponse, DiaAgendamento } from "../types";
+import { Agendamento, DiaAgendamento } from "../types";
+
+function normalizarData(data: string): string {
+  if (!data) return "";
+
+  if (/^\d{2}-\d{2}-\d{4}$/.test(data)) {
+    return data;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(data)) {
+    const [ano, mes, dia] = data.split("-");
+    return `${dia}-${mes}-${ano}`;
+  }
+
+  return data;
+}
+
+function dataHoraParaOrdenacao(data: string, hora: string): number {
+  const dataNormalizada = normalizarData(data);
+
+  const [dia, mes, ano] = dataNormalizada.split("-");
+  const [horas = "00", minutos = "00"] = hora.split(":");
+
+  return new Date(
+      Number(ano),
+      Number(mes) - 1,
+      Number(dia),
+      Number(horas),
+      Number(minutos)
+  ).getTime();
+}
 
 export function normalizarAgendamentos(
-  dto: DiaAgendamento[] = [],
+    dto: DiaAgendamento[] = [],
 ): Agendamento[] {
   const flatten: Agendamento[] = [];
 
   dto.forEach((dia) => {
-    dia.agendamentos?.forEach((a: AgendamentoResponse) => {
+    dia.agendamentos?.forEach((a) => {
       flatten.push({
-        id: a.atendimentoId,
+        id: a.id,
         pacienteId: a.pacienteId,
         paciente: a.nomePaciente,
         profissionalId: a.profissionalId || "",
         nomeProfissional: a.nomeProfissional || "Não informado",
-        horario: a.time.substring(0, 5), 
-        data: isoParaBR(a.data),
-        numeracao: String(a.numeroAtendimento ?? "0"),
+        horario: a.hora?.substring(0, 5) || "",
+        data: normalizarData(a.data || dia.dia),
+        numeracao: a.numeracao ?? "0",
         status: a.status,
-        externo: a.externo ?? false, 
+        externo: a.externo ?? false,
       });
     });
   });
 
-  return flatten;
+  return flatten.sort((a, b) => {
+    return dataHoraParaOrdenacao(a.data, a.horario) - dataHoraParaOrdenacao(b.data, b.horario);
+  });
 }


### PR DESCRIPTION
# Descrição

Este PR corrige a listagem de agendamentos na tela de agendamentos após a integração com os agendamentos do sistema geral.

O backend já estava retornando corretamente os registros pelo endpoint GET /agendamento, porém o frontend ainda esperava campos antigos do contrato da API, como atendimentoId, time e numeroAtendimento.

O contrato atual retorna os campos id, hora e numeracao, sendo numeracao mantida como string, conforme o schema do banco de dados.

Além disso, foi ajustada a ordenação dos agendamentos para que os horários mais próximos apareçam primeiro na tela.

## Alterações realizadas

- Ajusta os tipos da feature de agenda para refletirem o contrato atual da API.

### Corrige o normalizador de agendamentos para usar:

> id
> hora
> numeracao
> dia
> externo

- Mantém numeracao como string.
- Corrige a normalização de datas no formato DD-MM-YYYY.
- Ordena os agendamentos por data e hora em ordem crescente.
- Ajusta o card de agendamento para receber a numeração como string.
- Garante compatibilidade com agendamentos internos e externos.

## Problema corrigido

Antes, os agendamentos eram retornados corretamente pela API, mas não apareciam no frontend porque o normalizador esperava campos diferentes dos retornados pelo backend.

Também havia um problema de ordenação, onde os agendamentos mais próximos apareciam por último.

## Como testar

- Acessar a tela de agendamentos.
- Criar um novo agendamento.
- Verificar se o agendamento aparece na listagem.
- Conferir se os dados exibidos estão corretos:

> nome do paciente;
> horário;
> numeração;
> status.

- Criar agendamentos em datas diferentes.
- Confirmar que a listagem aparece em ordem cronológica crescente:
- datas mais próximas primeiro;
- horários mais cedo primeiro dentro do mesmo dia.