### PR TITLE
feat: add autonomous local development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,28 @@
-POSTGRES_USER=admin
-POSTGRES_PASSWORD=troque-esta-senha
-POSTGRES_DATABASE=atendimento_apae_db
+# Infraestrutura local
+POSTGRES_USER=atendimento_user
+POSTGRES_PASSWORD=atendimento_pass
+POSTGRES_DATABASE=atendimento_local
+POSTGRES_PORT=5300
 
-MINIO_ROOT_USER=minio
-MINIO_ROOT_PASSWORD=troque-esta-senha
+MINIO_ROOT_USER=atendimento_minio
+MINIO_ROOT_PASSWORD=atendimento_minio_123
+MINIO_API_PORT=9100
+MINIO_CONSOLE_PORT=9101
+BUCKET_NAME=apae-atendimento
 
-BUCKET_NAME=apae
+# Backend executado no host
+SERVER_PORT=8082
+SPRING_PROFILES_ACTIVE=dev
+DB_URL=jdbc:postgresql://localhost:5300/atendimento_local
+DB_USER=atendimento_user
+DB_PASSWORD=atendimento_pass
+MINIO_ENDPOINT=http://localhost:9100
+CORS_ALLOWED_ORIGINS=http://localhost:3001
 
-FRONT_END_URL=http://localhost
-NEXT_PUBLIC_API_URL=http://localhost:8080
-
-JWT_SECRET=troque-este-secret
+JWT_SECRET=YXRlbmRpbWVudG8tbG9jYWwtand0LXNlY3JldC0yNTYtYml0cw==
 JWT_EXPIRATION=30
 JWT_COOKIE_SECURE=false
+
+# Frontend executado no host
+FRONT_END_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:8082/atendimento

--- a/.scripts/db/apae-geral-contract.sql
+++ b/.scripts/db/apae-geral-contract.sql
@@ -1,0 +1,107 @@
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS apae_geral;
+CREATE SCHEMA IF NOT EXISTS gestao_escolar;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS apae_geral.areas_de_atendimento (
+    area VARCHAR(255) PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.enderecos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cidade VARCHAR(255) NOT NULL,
+    cep VARCHAR(255),
+    estado VARCHAR(255),
+    bairro VARCHAR(255) NOT NULL,
+    rua VARCHAR(255) NOT NULL,
+    numero VARCHAR(255) NOT NULL,
+    complemento VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.usuarios (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    cpf VARCHAR(255) UNIQUE,
+    senha VARCHAR(255),
+    nome_completo VARCHAR(255),
+    cargo VARCHAR(255) NOT NULL,
+    contato VARCHAR(255),
+    rg VARCHAR(255) UNIQUE,
+    endereco_id UUID REFERENCES apae_geral.enderecos(id),
+    primeiro_acesso BOOLEAN NOT NULL DEFAULT FALSE,
+    ativo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.profissionais_da_saude (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    usuario_id UUID NOT NULL UNIQUE REFERENCES apae_geral.usuarios(id),
+    ativo BOOLEAN NOT NULL DEFAULT TRUE,
+    documento_profissional VARCHAR(255) UNIQUE,
+    area_de_atendimento VARCHAR(255) REFERENCES apae_geral.areas_de_atendimento(area)
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.pacientes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    nome_completo VARCHAR(255) NOT NULL,
+    data_de_nascimento DATE NOT NULL,
+    cpf VARCHAR(255) UNIQUE,
+    contato VARCHAR(255) NOT NULL,
+    is_aluno BOOLEAN NOT NULL DEFAULT FALSE,
+    is_apagado BOOLEAN NOT NULL DEFAULT FALSE,
+    endereco_id UUID REFERENCES apae_geral.enderecos(id)
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.responsaveis (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    paciente_id UUID NOT NULL REFERENCES apae_geral.pacientes(id),
+    nome VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.transtornos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    nome VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.cadastros_anuais (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    paciente_id UUID NOT NULL REFERENCES apae_geral.pacientes(id),
+    ano INTEGER NOT NULL,
+    UNIQUE (paciente_id, ano)
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.cadastro_anual_transtorno (
+    cadastro_anual_id UUID NOT NULL REFERENCES apae_geral.cadastros_anuais(id),
+    transtorno_id UUID NOT NULL REFERENCES apae_geral.transtornos(id),
+    PRIMARY KEY (cadastro_anual_id, transtorno_id)
+);
+
+CREATE TABLE IF NOT EXISTS apae_geral.agendamentos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cadastro_anual_id UUID NOT NULL REFERENCES apae_geral.cadastros_anuais(id),
+    profissional_id UUID NOT NULL REFERENCES apae_geral.profissionais_da_saude(id),
+    frequencia_dias INTEGER NOT NULL DEFAULT 7,
+    hora TIME NOT NULL,
+    data_inicial DATE NOT NULL,
+    data_final DATE,
+    ativo BOOLEAN NOT NULL DEFAULT TRUE,
+    data_criacao TIMESTAMP,
+    substituido_por_id UUID,
+    atualizado_de_id UUID
+);
+
+CREATE OR REPLACE FUNCTION apae_geral.definir_senha_primeiro_acesso(
+    p_usuario_id UUID,
+    p_senha_hash TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE apae_geral.usuarios
+       SET senha = p_senha_hash,
+           primeiro_acesso = FALSE
+     WHERE id = p_usuario_id;
+END;
+$$;
+
+COMMIT;

--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MODE="${1:-both}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+
+load_env() {
+  if [ ! -f "$ENV_FILE" ]; then
+    cp "$ROOT_DIR/.env.example" "$ENV_FILE"
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+}
+
+run_backend() {
+  load_env
+  cd "$ROOT_DIR/backend/atendimento"
+  ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
+}
+
+run_frontend() {
+  load_env
+  cd "$ROOT_DIR/frontend/atendimento-app"
+  pnpm dev --port 3001
+}
+
+run_both() {
+  run_backend &
+  backend_pid=$!
+  run_frontend &
+  frontend_pid=$!
+
+  cleanup() {
+    kill "$backend_pid" "$frontend_pid" 2>/dev/null || true
+  }
+
+  trap cleanup INT TERM EXIT
+  wait -n "$backend_pid" "$frontend_pid"
+}
+
+case "$MODE" in
+  backend) run_backend ;;
+  frontend) run_frontend ;;
+  both) run_both ;;
+  *) echo "Uso: $0 [backend|frontend|both]"; exit 1 ;;
+esac

--- a/.scripts/seed/local-development.sql
+++ b/.scripts/seed/local-development.sql
@@ -1,0 +1,133 @@
+BEGIN;
+
+INSERT INTO apae_geral.areas_de_atendimento (area)
+VALUES ('Psicologia'), ('Fisioterapia')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.enderecos (id, cidade, cep, estado, bairro, rua, numero)
+VALUES
+    ('a1000000-0000-4000-8000-000000000001', 'Esperanca', '58135-000', 'PB', 'Centro', 'Rua Local Um', '100'),
+    ('a1000000-0000-4000-8000-000000000002', 'Esperanca', '58135-000', 'PB', 'Centro', 'Rua Local Dois', '200')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.usuarios
+    (id, email, cpf, senha, nome_completo, cargo, contato, rg, endereco_id, primeiro_acesso, ativo)
+VALUES
+    (
+        'a2000000-0000-4000-8000-000000000001',
+        'profissional@teste.local',
+        '000.000.010-82',
+        '$2y$10$EwPTyxIGnTEnI8CjJ.zYOOTWYgdGCrXYl3ZIbrnGqLUoaw9SQoiBe',
+        'Profissional de Atendimento Ficticio',
+        'ATENDIMENTO',
+        '(83) 90000-0010',
+        'LOCAL-ATEND-01',
+        'a1000000-0000-4000-8000-000000000001',
+        FALSE,
+        TRUE
+    )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.profissionais_da_saude
+    (id, usuario_id, ativo, documento_profissional, area_de_atendimento)
+VALUES
+    (
+        'a3000000-0000-4000-8000-000000000001',
+        'a2000000-0000-4000-8000-000000000001',
+        TRUE,
+        'CRP-LOCAL-ATEND-01',
+        'Psicologia'
+    )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.pacientes
+    (id, nome_completo, data_de_nascimento, cpf, contato, is_aluno, is_apagado, endereco_id)
+VALUES
+    ('a4000000-0000-4000-8000-000000000001', 'Paciente Ficticio Um', DATE '2014-05-10', '000.000.110-82', '(83) 90000-1010', TRUE, FALSE, 'a1000000-0000-4000-8000-000000000002'),
+    ('a4000000-0000-4000-8000-000000000002', 'Paciente Ficticio Dois', DATE '2016-08-20', '000.000.111-63', '(83) 90000-1011', FALSE, FALSE, 'a1000000-0000-4000-8000-000000000002')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.responsaveis (id, paciente_id, nome)
+VALUES
+    ('a4100000-0000-4000-8000-000000000001', 'a4000000-0000-4000-8000-000000000001', 'Responsavel Ficticio Um'),
+    ('a4100000-0000-4000-8000-000000000002', 'a4000000-0000-4000-8000-000000000002', 'Responsavel Ficticio Dois')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.transtornos (id, nome)
+VALUES
+    ('a5000000-0000-4000-8000-000000000001', 'Transtorno ficticio A'),
+    ('a5000000-0000-4000-8000-000000000002', 'Transtorno ficticio B')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.cadastros_anuais (id, paciente_id, ano)
+VALUES
+    ('a6000000-0000-4000-8000-000000000001', 'a4000000-0000-4000-8000-000000000001', EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER),
+    ('a6000000-0000-4000-8000-000000000002', 'a4000000-0000-4000-8000-000000000002', EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.cadastro_anual_transtorno (cadastro_anual_id, transtorno_id)
+VALUES
+    ('a6000000-0000-4000-8000-000000000001', 'a5000000-0000-4000-8000-000000000001'),
+    ('a6000000-0000-4000-8000-000000000002', 'a5000000-0000-4000-8000-000000000002')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO apae_geral.agendamentos
+    (id, cadastro_anual_id, profissional_id, frequencia_dias, hora, data_inicial, data_final, ativo, data_criacao)
+VALUES
+    (
+        'a7000000-0000-4000-8000-000000000001',
+        'a6000000-0000-4000-8000-000000000001',
+        'a3000000-0000-4000-8000-000000000001',
+        7,
+        TIME '09:00',
+        CURRENT_DATE,
+        CURRENT_DATE + 28,
+        TRUE,
+        CURRENT_TIMESTAMP
+    )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atendimento.profissional_paciente (profissional_id, paciente_id)
+VALUES
+    ('a3000000-0000-4000-8000-000000000001', 'a4000000-0000-4000-8000-000000000001'),
+    ('a3000000-0000-4000-8000-000000000001', 'a4000000-0000-4000-8000-000000000002')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atendimento.agendamento
+    (id, numeracao, status, data_hora, profissional_id, paciente_id)
+VALUES
+    (
+        'a8000000-0000-4000-8000-000000000001',
+        'AG-LOCAL-001',
+        FALSE,
+        CURRENT_TIMESTAMP + INTERVAL '2 days',
+        'a3000000-0000-4000-8000-000000000001',
+        'a4000000-0000-4000-8000-000000000001'
+    )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atendimento.atendimento
+    (id, numeracao, data_atendimento, paciente_id, profissional_id, status)
+VALUES
+    (
+        'a9000000-0000-4000-8000-000000000001',
+        'AT-LOCAL-001',
+        CURRENT_TIMESTAMP - INTERVAL '1 day',
+        'a4000000-0000-4000-8000-000000000001',
+        'a3000000-0000-4000-8000-000000000001',
+        TRUE
+    )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO atendimento.topico (id, atendimento_id, ordem, titulo, descricao)
+VALUES
+    (
+        'aa000000-0000-4000-8000-000000000001',
+        'a9000000-0000-4000-8000-000000000001',
+        1,
+        'Evolucao ficticia',
+        'Registro criado exclusivamente para desenvolvimento local.'
+    )
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/.scripts/setup.sh
+++ b/.scripts/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+
+cd "$ROOT_DIR"
+
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.example .env
+  echo "[.env] Criado a partir de .env.example"
+fi
+
+echo "Subindo PostgreSQL e MinIO locais..."
+docker compose up -d postgres-db minio
+
+echo "Criando contratos mockados de apae_geral e o schema gestao_escolar..."
+docker compose --profile tools run --rm db-contract
+
+echo "Aplicando migrations Flyway do schema atendimento..."
+docker compose --profile tools run --rm db-migrate
+
+if [ "${1:-}" != "--no-seed" ]; then
+  echo "Inserindo dados ficticios e idempotentes..."
+  docker compose --profile tools run --rm db-seed
+fi
+
+echo "Banco local do Atendimento preparado."

--- a/README.md
+++ b/README.md
@@ -53,6 +53,51 @@ A intenção do sistema é modernizar e unificar o processo de acompanhamento do
 
 # Como Rodar o Projeto
 
+## Desenvolvimento local autonomo
+
+O Atendimento pode ser executado sem iniciar o APAE-Geral ou o Gestao Escolar.
+O PostgreSQL local reproduz os tres schemas do Neon:
+
+- `atendimento`: schema real do produto, versionado pelas migrations Flyway V1-V9;
+- `apae_geral`: contrato minimo mockado com usuarios, profissionais, pacientes e agenda externa;
+- `gestao_escolar`: schema presente, mas vazio, pois o Atendimento nao o consulta.
+
+Na raiz do repositorio:
+
+```bash
+cp .env.example .env
+pnpm --dir frontend/atendimento-app install
+pnpm db:prepare
+pnpm dev
+```
+
+Servicos locais:
+
+- Frontend: `http://localhost:3001`
+- Backend: `http://localhost:8082/atendimento`
+- Health check: `http://localhost:8082/atendimento/actuator/health`
+- PostgreSQL: `localhost:5300`
+- MinIO: `http://localhost:9100` (console em `http://localhost:9101`)
+
+Credenciais ficticias:
+
+- E-mail: `profissional@teste.local`
+- Senha: `12345678`
+
+Comandos uteis:
+
+```bash
+pnpm db:prepare    # contratos, migrations, seed e MinIO
+pnpm db:migrate    # reaplica apenas as migrations pendentes
+pnpm db:seed       # reaplica o seed idempotente
+pnpm docker:down   # para containers e preserva volumes
+pnpm docker:drop   # apaga os volumes e todos os dados locais
+```
+
+Os objetos de `apae_geral` sao contratos locais de desenvolvimento, nao uma copia
+do schema pertencente ao APAE-Geral. Alteracoes reais desse contrato devem ser
+sincronizadas manualmente quando o produto de origem mudar.
+
 Para executar o sistema completo em sua máquina, siga os passos abaixo:
 
 ### Pré-requisitos

--- a/backend/atendimento/src/main/resources/application-dev.properties
+++ b/backend/atendimento/src/main/resources/application-dev.properties
@@ -1,5 +1,6 @@
-#Configuracao de Importacao Inteligente
-spring.config.import=optional:file:.env,optional:file:../../.env,optional:file:./backend/docker/local-secrets.properties,optional:file:../docker/local-secrets.properties
+# A configuracao local fica na raiz do repositorio. Um .env ao lado do pom
+# continua sendo aceito e tem precedencia para configuracoes pessoais.
+spring.config.import=optional:file:../../.env[.properties],optional:file:.env[.properties]
 
 #Conexao com Banco Local (PostgreSQL)
 spring.datasource.url=${DB_URL}
@@ -26,3 +27,6 @@ minio.endpoint=${MINIO_ENDPOINT:http://localhost:9000}
 minio.root.user=${MINIO_ROOT_USER}
 minio.root.password=${MINIO_ROOT_PASSWORD}
 bucket.name=${BUCKET_NAME:apae}
+
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,32 +1,86 @@
+name: apae-atendimento
+
 services:
   postgres-db:
     image: postgres:16
     container_name: postgres-atendimento-apae
-    restart: always
+    restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DATABASE}
+      POSTGRES_USER: ${POSTGRES_USER:-atendimento_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-atendimento_pass}
+      POSTGRES_DB: ${POSTGRES_DATABASE:-atendimento_local}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5300}:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
-    command: >
-      postgres
-      -c listen_addresses='*'
-      -c port=5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-atendimento_user} -d ${POSTGRES_DATABASE:-atendimento_local}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  db-contract:
+    image: postgres:16
+    profiles: ["tools"]
+    environment:
+      PGHOST: postgres-db
+      PGPORT: 5432
+      PGDATABASE: ${POSTGRES_DATABASE:-atendimento_local}
+      PGUSER: ${POSTGRES_USER:-atendimento_user}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-atendimento_pass}
+    command: ["psql", "-v", "ON_ERROR_STOP=1", "-f", "/contracts/apae-geral.sql"]
+    volumes:
+      - ./.scripts/db/apae-geral-contract.sql:/contracts/apae-geral.sql:ro,z
+    depends_on:
+      postgres-db:
+        condition: service_healthy
+
+  db-migrate:
+    image: flyway/flyway:11.7.2
+    profiles: ["tools"]
+    command:
+      - -url=jdbc:postgresql://postgres-db:5432/${POSTGRES_DATABASE:-atendimento_local}
+      - -user=${POSTGRES_USER:-atendimento_user}
+      - -password=${POSTGRES_PASSWORD:-atendimento_pass}
+      - -schemas=atendimento
+      - -defaultSchema=atendimento
+      - -createSchemas=true
+      - -locations=filesystem:/flyway/sql
+      - -connectRetries=20
+      - migrate
+    volumes:
+      - ./backend/atendimento/src/main/resources/db/migration:/flyway/sql:ro,z
+    depends_on:
+      db-contract:
+        condition: service_completed_successfully
+
+  db-seed:
+    image: postgres:16
+    profiles: ["tools"]
+    environment:
+      PGHOST: postgres-db
+      PGPORT: 5432
+      PGDATABASE: ${POSTGRES_DATABASE:-atendimento_local}
+      PGUSER: ${POSTGRES_USER:-atendimento_user}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-atendimento_pass}
+    command: ["psql", "-v", "ON_ERROR_STOP=1", "-f", "/seed/local-development.sql"]
+    volumes:
+      - ./.scripts/seed/local-development.sql:/seed/local-development.sql:ro,z
+    depends_on:
+      db-migrate:
+        condition: service_completed_successfully
 
   minio:
     image: minio/minio:latest
     container_name: minio-atendimento-apae
     command: server /data --console-address ":9001"
-    restart: always
+    restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-atendimento_minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-atendimento_minio_123}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${MINIO_API_PORT:-9100}:9000"
+      - "${MINIO_CONSOLE_PORT:-9101}:9001"
     volumes:
       - minio-data:/data
 
@@ -40,30 +94,24 @@ services:
       - .env
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      DB_URL: jdbc:postgresql://postgres-db:5432/${POSTGRES_DATABASE}
-      DB_USER: ${POSTGRES_USER}
-      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      SERVER_PORT: 8080
+      DB_URL: jdbc:postgresql://postgres-db:5432/${POSTGRES_DATABASE:-atendimento_local}
+      DB_USER: ${POSTGRES_USER:-atendimento_user}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-atendimento_pass}
       S3_ENDPOINT: http://minio:9000
-      S3_EXTERNAL_ENDPOINT: http://localhost:9000
+      S3_EXTERNAL_ENDPOINT: http://localhost:${MINIO_API_PORT:-9100}
       S3_REGION: us-east-1
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
-      BUCKET_NAME: ${BUCKET_NAME}
-      FRONT_END_URL: ${FRONT_END_URL}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:-atendimento_minio}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-atendimento_minio_123}
+      BUCKET_NAME: ${BUCKET_NAME:-apae-atendimento}
+      FRONT_END_URL: ${FRONT_END_URL:-http://localhost:3001}
     ports:
       - "8080:8080"
     depends_on:
-      - postgres-db
-      - minio
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -fsS http://localhost:8080/actuator/health > /dev/null || exit 1",
-        ]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      db-migrate:
+        condition: service_completed_successfully
+      minio:
+        condition: service_started
     profiles: ["PROD"]
 
   frontend:
@@ -72,23 +120,14 @@ services:
       context: ./frontend/atendimento-app
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080/atendimento}
     restart: unless-stopped
     environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080/atendimento}
     ports:
-      - "80:3000"
+      - "3001:3000"
     depends_on:
       - backend
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -fsS http://localhost:3000/login > /dev/null || exit 1",
-        ]
-      interval: 30s
-      timeout: 5s
-      retries: 3
     profiles: ["PROD"]
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apae/atendimento",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.33.0",
+  "scripts": {
+    "dev:infra": "bash ./.scripts/setup.sh --no-seed",
+    "dev:backend": "bash ./.scripts/run-app.sh backend",
+    "dev:frontend": "bash ./.scripts/run-app.sh frontend",
+    "dev": "pnpm db:prepare && bash ./.scripts/run-app.sh both",
+    "db:contract": "docker compose --profile tools run --rm db-contract",
+    "db:migrate": "docker compose --profile tools run --rm db-migrate",
+    "db:seed": "docker compose --profile tools run --rm db-seed",
+    "db:prepare": "bash ./.scripts/setup.sh",
+    "docker:down": "docker compose down",
+    "docker:drop": "docker compose down -v"
+  }
+}


### PR DESCRIPTION
# O que mudou?

Este PR adiciona um ambiente de desenvolvimento local autônomo para o produto APAE Atendimento.

O objetivo é permitir que cada desenvolvedor execute o Atendimento sem depender do banco compartilhado no Neon e sem precisar iniciar simultaneamente os produtos APAE-Geral e Gestão Escolar.

O PostgreSQL local reproduz a arquitetura de schemas utilizada no Neon:

- `atendimento`: schema real do produto, gerenciado pelas migrations Flyway;
- `apae_geral`: contrato local mínimo com dados fictícios necessários ao Atendimento;
- `gestao_escolar`: schema criado vazio, pois atualmente não é consultado pelo Atendimento.


## Mudanças Realizadas

- Adição de PostgreSQL e MinIO locais por meio do Docker Compose.
- Criação automática dos schemas `atendimento`, `apae_geral` e `gestao_escolar`.
- Execução das migrations Flyway V1–V9 do schema `atendimento`.
- Criação de um contrato mínimo das tabelas externas pertencentes ao APAE-Geral.
- Adição de seed local fictício e idempotente com profissionais, pacientes, responsáveis, atendimentos, tópicos, anexos e agendamentos.
- Adição dos comandos `pnpm db:prepare`, `pnpm db:migrate`, `pnpm db:seed`, `pnpm docker:down` e `pnpm docker:drop`.
- Adição de um comando único `pnpm dev` para iniciar infraestrutura, backend e frontend.
- Configuração de portas exclusivas para evitar conflitos com os outros produtos.
- Atualização das variáveis de ambiente locais e da documentação do projeto.
- Correção do carregamento das variáveis de ambiente pelo backend.
- Correção do comando de inicialização do frontend na porta 3001.

## Evidências

A implementação foi validada em um banco criado do zero:

- PostgreSQL iniciado em `localhost:5300`.
- MinIO iniciado em `localhost:9100`.
- Frontend iniciado em `http://localhost:3001`.
- Backend iniciado em `http://localhost:8082/atendimento`.
- Health check do backend retornando `{"status":"UP"}`.
- Três schemas criados: `apae_geral`, `atendimento` e `gestao_escolar`.
- Nove migrations Flyway aplicadas com sucesso, deixando o schema `atendimento` na versão V9.
- Seed executado repetidamente sem duplicar registros.
- Login fictício validado com sucesso:
  - E-mail: `profissional@teste.local`
  - Senha: `12345678`
- Build do backend concluído com sucesso.
- Build do frontend concluído com sucesso.